### PR TITLE
Migrate to valentiay.dev org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # phobos
-[![Maven Central](https://img.shields.io/maven-central/v/ru.tinkoff/phobos-core_2.13.svg)](https://search.maven.org/search?q=ru.tinkoff.phobos-core)
-[![Build](https://github.com/TinkoffCreditSystems/phobos/actions/workflows/scala.yml/badge.svg)](https://github.com/TinkoffCreditSystems/phobos/actions/workflows/scala.yml)
-[![Scala Steward](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
+[![Maven Central](https://img.shields.io/maven-central/v/dev.valentiay/phobos-core_2.13.svg)](https://search.maven.org/search?q=dev.valentiay.phobos-core)
+[![Build](https://github.com/valentiay/phobos/actions/workflows/scala.yml/badge.svg)](https://github.com/valentiay/phobos/actions/workflows/scala.yml)
 [![Discord](https://img.shields.io/badge/chat-discord-blue)](https://discord.gg/S9Ad88t)
 
 Phobos is an XML data-binding library based on stream parsing. 
@@ -13,15 +12,15 @@ Scala 2.12, 2.13 and 3 are supported. See [Supported Scala versions](#supported-
 Add phobos-core to your dependencies:
 
 ```
-libraryDependencies += "ru.tinkoff" %% "phobos-core" % "0.21.0"
+libraryDependencies += "dev.valentiay" %% "phobos-core" % "0.21.0"
 ```
 
 Then try this code out in `sbt console` or in a separate source file:
 ```scala
-import ru.tinkoff.phobos.decoding._
-import ru.tinkoff.phobos.encoding._
-import ru.tinkoff.phobos.syntax._
-import ru.tinkoff.phobos.derivation.semiauto._
+import phobos.decoding._
+import phobos.encoding._
+import phobos.syntax._
+import phobos.derivation.semiauto._
 
 case class TravelPoint(country: String, city: String)
 object TravelPoint {
@@ -66,7 +65,7 @@ Performance details can be found out in [phobos-benchmark repository](https://gi
 There are several additional modules for some specific cases. 
 These modules could be added with command below:
 ```
-libraryDependencies += "ru.tinkoff" %% "phobos-<module>" % "0.21.0"
+libraryDependencies += "dev.valentiay" %% "phobos-<module>" % "0.21.0"
 ```
 Where `<module>` is module name.
 
@@ -104,6 +103,3 @@ Detailed information about supported Scala versions is in the table below. Avail
 | fs2-ce2     |  ✓   |  ✓   | ✓ |
 | monix       |  ✓   |  ✓   | ✓ |
 | refined     |  ✓   |  ✓   |   |
-
-## XSD and WSDL code-generation support
-Classes from XSD could be generated using [deimos](https://github.com/Tinkoff/deimos) library.

--- a/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/Envelope.scala
+++ b/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/Envelope.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.akka_http
+package phobos.akka_http
 
-import ru.tinkoff.phobos.decoding.{ElementDecoder, XmlDecoder}
-import ru.tinkoff.phobos.derivation.semiauto._
-import ru.tinkoff.phobos.encoding.{ElementEncoder, XmlEncoder}
-import ru.tinkoff.phobos.syntax.xmlns
+import phobos.decoding.{ElementDecoder, XmlDecoder}
+import phobos.derivation.semiauto._
+import phobos.encoding.{ElementEncoder, XmlEncoder}
+import phobos.syntax.xmlns
 
 final case class Envelope[Header, Body](@xmlns(soapenv) Header: Header, @xmlns(soapenv) Body: Body)
 

--- a/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/HeadlessEnvelope.scala
+++ b/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/HeadlessEnvelope.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.akka_http
+package phobos.akka_http
 
-import ru.tinkoff.phobos.decoding.{ElementDecoder, XmlDecoder}
-import ru.tinkoff.phobos.derivation.semiauto._
-import ru.tinkoff.phobos.encoding.{ElementEncoder, XmlEncoder}
-import ru.tinkoff.phobos.syntax.xmlns
+import phobos.decoding.{ElementDecoder, XmlDecoder}
+import phobos.derivation.semiauto._
+import phobos.encoding.{ElementEncoder, XmlEncoder}
+import phobos.syntax.xmlns
 
 final case class HeadlessEnvelope[Body](@xmlns(soapenv) Body: Body)
 

--- a/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/marshalling/application.scala
+++ b/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/marshalling/application.scala
@@ -1,10 +1,10 @@
-package ru.tinkoff.phobos.akka_http.marshalling
+package phobos.akka_http.marshalling
 
 import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
 import akka.http.scaladsl.model.{HttpCharsets, HttpEntity, MediaTypes}
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.encoding.XmlEncoder
+import phobos.decoding.XmlDecoder
+import phobos.encoding.XmlEncoder
 
 object application {
   implicit def soapApplicationXmlMarshaller[T](implicit encoder: XmlEncoder[T]): ToEntityMarshaller[T] =

--- a/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/marshalling/text.scala
+++ b/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/marshalling/text.scala
@@ -1,11 +1,11 @@
-package ru.tinkoff.phobos.akka_http.marshalling
+package phobos.akka_http.marshalling
 
 import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
 import akka.http.scaladsl.model.ContentTypes.`text/xml(UTF-8)`
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.encoding.XmlEncoder
+import phobos.decoding.XmlDecoder
+import phobos.encoding.XmlEncoder
 
 object text {
   implicit def soapTextXmlMarshaller[T](implicit encoder: XmlEncoder[T]): ToEntityMarshaller[T] =

--- a/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/soapenv.scala
+++ b/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/soapenv.scala
@@ -1,5 +1,5 @@
-package ru.tinkoff.phobos.akka_http
-import ru.tinkoff.phobos.Namespace
+package phobos.akka_http
+import phobos.Namespace
 
 case class soapenv()
 

--- a/modules/akka-http/src/test/scala/ru/tinkoff/phobos/akka_http/SoapTest.scala
+++ b/modules/akka-http/src/test/scala/ru/tinkoff/phobos/akka_http/SoapTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.akka_http
+package phobos.akka_http
 
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
@@ -7,9 +7,9 @@ class SoapTest extends AnyWordSpec with Matchers {
   "Soap codecs" should {
     "be found for envelope" in {
       """
-       | import ru.tinkoff.phobos.encoding.XmlEncoder
-       | import ru.tinkoff.phobos.decoding.XmlDecoder
-       | import ru.tinkoff.phobos.annotations.ElementCodec
+       | import phobos.encoding.XmlEncoder
+       | import phobos.decoding.XmlDecoder
+       | import phobos.annotations.ElementCodec
        | @ElementCodec
        | case class Header(foo: Int)
        | @ElementCodec
@@ -21,9 +21,9 @@ class SoapTest extends AnyWordSpec with Matchers {
 
     "be found for headless envelope" in {
       """
-       | import ru.tinkoff.phobos.encoding.XmlEncoder
-       | import ru.tinkoff.phobos.decoding.XmlDecoder
-       | import ru.tinkoff.phobos.annotations.ElementCodec
+       | import phobos.encoding.XmlEncoder
+       | import phobos.decoding.XmlDecoder
+       | import phobos.annotations.ElementCodec
        | @ElementCodec
        | case class Body(bar: String)
        | implicitly[XmlEncoder[HeadlessEnvelope[Body]]]

--- a/modules/akka-http/src/test/scala/ru/tinkoff/phobos/akka_http/marshalling/ApplicationTest.scala
+++ b/modules/akka-http/src/test/scala/ru/tinkoff/phobos/akka_http/marshalling/ApplicationTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.akka_http.marshalling
+package phobos.akka_http.marshalling
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -9,8 +9,8 @@ class ApplicationTest extends AnyWordSpec with Matchers {
       """
        | import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
        | import akka.http.scaladsl.marshalling.ToResponseMarshaller
-       | import ru.tinkoff.phobos.akka_http.marshalling.application._
-       | import ru.tinkoff.phobos.annotations.XmlCodec
+       | import phobos.akka_http.marshalling.application._
+       | import phobos.annotations.XmlCodec
        | @XmlCodec("request")
        | case class Body(bar: String)
        | implicitly[FromRequestUnmarshaller[Body]]

--- a/modules/akka-http/src/test/scala/ru/tinkoff/phobos/akka_http/marshalling/TextTest.scala
+++ b/modules/akka-http/src/test/scala/ru/tinkoff/phobos/akka_http/marshalling/TextTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.akka_http.marshalling
+package phobos.akka_http.marshalling
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -9,8 +9,8 @@ class TextTest extends AnyWordSpec with Matchers {
       """
        | import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
        | import akka.http.scaladsl.marshalling.ToResponseMarshaller
-       | import ru.tinkoff.phobos.akka_http.marshalling.text._
-       | import ru.tinkoff.phobos.annotations.XmlCodec
+       | import phobos.akka_http.marshalling.text._
+       | import phobos.annotations.XmlCodec
        | @XmlCodec("request")
        | case class Body(bar: String)
        | implicitly[FromRequestUnmarshaller[Body]]

--- a/modules/akka-stream/src/main/scala/ru/tinkoff/phobos/akka_stream.scala
+++ b/modules/akka-stream/src/main/scala/ru/tinkoff/phobos/akka_stream.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos
+package phobos
 
 object akka_stream extends ops.AkkaStreamOps

--- a/modules/akka-stream/src/main/scala/ru/tinkoff/phobos/ops/AkkaStreamOps.scala
+++ b/modules/akka-stream/src/main/scala/ru/tinkoff/phobos/ops/AkkaStreamOps.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.ops
+package phobos.ops
 
 import akka.NotUsed
 import akka.stream.scaladsl.{Flow, Keep, Sink}
 import javax.xml.stream.XMLStreamConstants
-import ru.tinkoff.phobos.decoding._
+import phobos.decoding._
 import scala.concurrent.Future
 
 private[phobos] trait AkkaStreamOps {

--- a/modules/akka-stream/src/test/scala/ru/tinkoff/phobos/test/AkkaStreamTest.scala
+++ b/modules/akka-stream/src/test/scala/ru/tinkoff/phobos/test/AkkaStreamTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.test
+package phobos.test
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source}
@@ -7,12 +7,12 @@ import akka.testkit.TestKit
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.wordspec.AsyncWordSpecLike
-import ru.tinkoff.phobos.akka_stream._
-import ru.tinkoff.phobos.decoding.ElementDecoder
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.derivation.semiauto.deriveElementDecoder
-import ru.tinkoff.phobos.derivation.semiauto.deriveXmlDecoder
-import ru.tinkoff.phobos.syntax.text
+import phobos.akka_stream._
+import phobos.decoding.ElementDecoder
+import phobos.decoding.XmlDecoder
+import phobos.derivation.semiauto.deriveElementDecoder
+import phobos.derivation.semiauto.deriveXmlDecoder
+import phobos.syntax.text
 
 import scala.concurrent.duration._
 

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/AstTraversalLogic.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/AstTraversalLogic.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos.ast
+package phobos.ast
 
-import ru.tinkoff.phobos.traverse.DecodingTraversalLogic
+import phobos.traverse.DecodingTraversalLogic
 import AstTraversalLogic._
 import scala.collection.mutable
 

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/XmlEntry.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/XmlEntry.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.ast
+package phobos.ast
 
-import ru.tinkoff.phobos.ast.impl.{Attr, NodePair, XmlBuildingBlock}
-import ru.tinkoff.phobos.decoding.{AttributeDecoder, ElementDecoder}
-import ru.tinkoff.phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder}
-import ru.tinkoff.phobos.traverse.GenericElementDecoder
+import phobos.ast.impl.{Attr, NodePair, XmlBuildingBlock}
+import phobos.decoding.{AttributeDecoder, ElementDecoder}
+import phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder}
+import phobos.traverse.GenericElementDecoder
 
 /** Base type for XML nodes, elements and attributes values
   */

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/XmlEntryElementEncoder.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/XmlEntryElementEncoder.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos.ast
+package phobos.ast
 
-import ru.tinkoff.phobos.encoding.{ElementEncoder, PhobosStreamWriter}
+import phobos.encoding.{ElementEncoder, PhobosStreamWriter}
 
 private[phobos] object XmlEntryElementEncoder extends ElementEncoder[XmlEntry] {
 

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/impl/CatsInstances.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/impl/CatsInstances.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.ast.impl
+package phobos.ast.impl
 
 import cats.Eq
-import ru.tinkoff.phobos.ast.XmlEntry
+import phobos.ast.XmlEntry
 
 trait CatsInstances {
   implicit val eqForAst: Eq[XmlEntry] = Eq.fromUniversalEquals[XmlEntry]

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/impl/builders.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/impl/builders.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos.ast.impl
+package phobos.ast.impl
 
-import ru.tinkoff.phobos.ast._
+import phobos.ast._
 
 sealed trait XmlBuildingBlock
 class AttrName(private val name: String) extends AnyVal {

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/package.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/ast/package.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos
+package phobos
 
-import ru.tinkoff.phobos.ast.impl.XmlBuildingBlock
+import phobos.ast.impl.XmlBuildingBlock
 
 package object ast {
 

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/raw/ElementsFlatten.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/raw/ElementsFlatten.scala
@@ -1,8 +1,8 @@
-package ru.tinkoff.phobos.raw
+package phobos.raw
 
-import ru.tinkoff.phobos.ast._
-import ru.tinkoff.phobos.decoding.ElementDecoder
-import ru.tinkoff.phobos.traverse.GenericElementDecoder
+import phobos.ast._
+import phobos.decoding.ElementDecoder
+import phobos.traverse.GenericElementDecoder
 
 /** Data type containing pairs of the element name and it's text.
   */

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/raw/ElementsFlattenTraversalLogic.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/raw/ElementsFlattenTraversalLogic.scala
@@ -1,8 +1,8 @@
-package ru.tinkoff.phobos.raw
+package phobos.raw
 
-import ru.tinkoff.phobos.ast.XmlLeaf
-import ru.tinkoff.phobos.raw.ElementsFlattenTraversalLogic.Accumulator
-import ru.tinkoff.phobos.traverse.DecodingTraversalLogic
+import phobos.ast.XmlLeaf
+import phobos.raw.ElementsFlattenTraversalLogic.Accumulator
+import phobos.traverse.DecodingTraversalLogic
 import scala.collection.mutable.ListBuffer
 
 class ElementsFlattenTraversalLogic private () extends DecodingTraversalLogic[Accumulator, ElementsFlatten] {

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/traverse/DecodingTraversalLogic.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/traverse/DecodingTraversalLogic.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos.traverse
+package phobos.traverse
 
-import ru.tinkoff.phobos.ast.XmlLeaf
+import phobos.ast.XmlLeaf
 
 /** Abstraction allowing to traverse arbitrary XML node(s). Works with both mutable and immutable accumulators
   *

--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/traverse/GenericElementDecoder.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/traverse/GenericElementDecoder.scala
@@ -1,11 +1,11 @@
-package ru.tinkoff.phobos.traverse
+package phobos.traverse
 
 import cats.syntax.traverse._
 import cats.instances.either._
 import cats.instances.list._
 import com.fasterxml.aalto.AsyncXMLStreamReader
-import ru.tinkoff.phobos.ast._
-import ru.tinkoff.phobos.decoding.{Cursor, DecodingError, ElementDecoder, TextDecoder}
+import phobos.ast._
+import phobos.decoding.{Cursor, DecodingError, ElementDecoder, TextDecoder}
 import scala.annotation.tailrec
 import scala.util.Try
 import GenericElementDecoder.DecoderState

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/CodecProperties.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/CodecProperties.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.ast
+package phobos.ast
 
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.encoding.XmlEncoder
+import phobos.decoding.XmlDecoder
+import phobos.encoding.XmlEncoder
 import org.scalacheck.{Arbitrary, Gen}
 
 class CodecProperties extends Properties("Ast codecs") {

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementDecoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementDecoderTest.scala
@@ -1,12 +1,12 @@
-package ru.tinkoff.phobos.ast
+package phobos.ast
 
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffShouldMatcher
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.decoding.{DecodingError, XmlDecoder}
+import phobos.Namespace
+import phobos.decoding.{DecodingError, XmlDecoder}
 import cats.syntax.either._
 
 class XmlEntryElementDecoderTest extends AnyWordSpec with Matchers with DiffShouldMatcher with EitherValues {
@@ -21,15 +21,15 @@ class XmlEntryElementDecoderTest extends AnyWordSpec with Matchers with DiffShou
     }
 
     "decodes complicated Xml into ast correctly" in {
-      case object tinkoff {
-        type ns = tinkoff.type
-        implicit val ns: Namespace[tinkoff.type] = Namespace.mkInstance("https://tinkoff.ru")
+      case object example {
+        type ns = example.type
+        implicit val ns: Namespace[example.type] = Namespace.mkInstance("https://example.org")
       }
 
       val sampleXml =
-        """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://tinkoff.ru" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>"""
+        """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://example.org" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>"""
 
-      val decodedAst = XmlDecoder.fromElementDecoderNs[XmlEntry, tinkoff.ns]("ast").decode(sampleXml)
+      val decodedAst = XmlDecoder.fromElementDecoderNs[XmlEntry, example.ns]("ast").decode(sampleXml)
       val expectedResult: XmlEntry = xml(attr("foo") := 5)(
         node("bar") := "bazz",
         node("array") := xml(
@@ -58,7 +58,7 @@ class XmlEntryElementDecoderTest extends AnyWordSpec with Matchers with DiffShou
           ),
       )
 
-      val encoded = ru.tinkoff.phobos.encoding.XmlEncoder.fromElementEncoder[XmlEntry]("ast").encode(n)
+      val encoded = phobos.encoding.XmlEncoder.fromElementEncoder[XmlEntry]("ast").encode(n)
 
       val result = encoded.flatMap(XmlDecoder.fromElementDecoder[XmlEntry]("ast").decode(_))
 

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementEncoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementEncoderTest.scala
@@ -1,10 +1,10 @@
-package ru.tinkoff.phobos.ast
+package phobos.ast
 
 import com.softwaremill.diffx.scalatest.DiffShouldMatcher
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.encoding.XmlEncoder
+import phobos.Namespace
+import phobos.encoding.XmlEncoder
 
 class XmlEntryElementEncoderTest extends AnyWordSpec with DiffShouldMatcher with Matchers {
   "XmlEntry encoder" should {
@@ -19,9 +19,9 @@ class XmlEntryElementEncoderTest extends AnyWordSpec with DiffShouldMatcher with
       assert(result == Right("""<?xml version='1.0' encoding='UTF-8'?><ast foo="5"><bar>bazz</bar></ast>"""))
     }
     "encodes nested Xml ast correctly" in {
-      case object tinkoff {
-        type ns = tinkoff.type
-        implicit val ns: Namespace[tinkoff.type] = Namespace.mkInstance("https://tinkoff.ru")
+      case object example {
+        type ns = example.type
+        implicit val ns: Namespace[example.type] = Namespace.mkInstance("https://example.org")
       }
 
       val ast = xml(attr("foo") := 5)(
@@ -42,12 +42,12 @@ class XmlEntryElementEncoderTest extends AnyWordSpec with DiffShouldMatcher with
 
       val result =
         XmlEncoder
-          .fromElementEncoderNs[XmlEntry, tinkoff.ns]("ast")
+          .fromElementEncoderNs[XmlEntry, example.ns]("ast")
           .encode(ast)
 
       assert(
         result == Right(
-          """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://tinkoff.ru" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>""",
+          """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://example.org" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>""",
         ),
       )
     }

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/util/AstTransformer.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/util/AstTransformer.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos.ast.util
+package phobos.ast.util
 
-import ru.tinkoff.phobos.ast._
+import phobos.ast._
 
 object AstTransformer {
   def sortNodeValues(xmlEntry: XmlEntry): XmlEntry = xmlEntry match {

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/raw/FlattenElementsDecoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/raw/FlattenElementsDecoderTest.scala
@@ -1,10 +1,10 @@
-package ru.tinkoff.phobos.raw
+package phobos.raw
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.ast._
+import phobos.Namespace
+import phobos.decoding.XmlDecoder
+import phobos.ast._
 
 class FlattenElementsDecoderTest extends AnyWordSpec with Matchers {
 
@@ -22,15 +22,15 @@ class FlattenElementsDecoderTest extends AnyWordSpec with Matchers {
     }
 
     "decodes complicated Xml into ast correctly" in {
-      case object tinkoff {
-        type ns = tinkoff.type
-        implicit val ns: Namespace[tinkoff.type] = Namespace.mkInstance("https://tinkoff.ru")
+      case object example {
+        type ns = example.type
+        implicit val ns: Namespace[example.type] = Namespace.mkInstance("https://example.org")
       }
 
       val xml =
-        """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://tinkoff.ru" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>"""
+        """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://example.org" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>"""
 
-      val decodedRaw = XmlDecoder.fromElementDecoderNs[ElementsFlatten, tinkoff.ns]("ast").decode(xml)
+      val decodedRaw = XmlDecoder.fromElementDecoderNs[ElementsFlatten, example.ns]("ast").decode(xml)
       assert(
         decodedRaw.contains(
           ElementsFlatten(

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/traverse/GenericElementDecoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/traverse/GenericElementDecoderTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.traverse
+package phobos.traverse
 
 import cats.syntax.either._
 import com.softwaremill.diffx.scalatest.DiffShouldMatcher
@@ -6,8 +6,8 @@ import com.softwaremill.diffx.generic.auto._
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.ast.XmlLeaf
-import ru.tinkoff.phobos.decoding.{DecodingError, ElementDecoder, XmlDecoder}
+import phobos.ast.XmlLeaf
+import phobos.decoding.{DecodingError, ElementDecoder, XmlDecoder}
 
 class GenericElementDecoderTest extends AnyWordSpec with Matchers with DiffShouldMatcher with EitherValues {
   import GenericElementDecoderTest._
@@ -18,7 +18,7 @@ class GenericElementDecoderTest extends AnyWordSpec with Matchers with DiffShoul
         .fromElementDecoder[Acc]("ast")
 
       val sampleXml =
-        """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://tinkoff.ru" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested x="2.0"><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>"""
+        """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://example.org" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested x="2.0"><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>"""
 
       val expectedResult0 = Acc(
         Map(
@@ -32,7 +32,7 @@ class GenericElementDecoderTest extends AnyWordSpec with Matchers with DiffShoul
       xmlDecoder.decode(sampleXml) shouldMatchTo (expectedResult0.asRight[DecodingError])
 
       val xmlWithoutAttrs =
-        """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://tinkoff.ru"><bar>bazz</bar><array><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>"""
+        """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://example.org"><bar>bazz</bar><array><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>"""
 
       val expectedResult1 = Acc(Map.empty)
 

--- a/modules/cats/src/main/scala/ru/tinkoff/phobos/catsInstances.scala
+++ b/modules/cats/src/main/scala/ru/tinkoff/phobos/catsInstances.scala
@@ -1,13 +1,13 @@
-package ru.tinkoff.phobos
+package phobos
 
 import cats.{Contravariant, Foldable, Functor}
 import cats.data.{Chain, NonEmptyChain, NonEmptyList, NonEmptySet, NonEmptyVector}
 import javax.xml.stream.XMLStreamConstants
-import ru.tinkoff.phobos.decoding.ElementDecoder.{listDecoder, vectorDecoder}
-import ru.tinkoff.phobos.decoding.XmlDecoder.createStreamReader
-import ru.tinkoff.phobos.decoding._
-import ru.tinkoff.phobos.encoding.ElementEncoder.{iteratorEncoder, listEncoder, setEncoder, vectorEncoder}
-import ru.tinkoff.phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder}
+import phobos.decoding.ElementDecoder.{listDecoder, vectorDecoder}
+import phobos.decoding.XmlDecoder.createStreamReader
+import phobos.decoding._
+import phobos.encoding.ElementEncoder.{iteratorEncoder, listEncoder, setEncoder, vectorEncoder}
+import phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder}
 
 object catsInstances {
   implicit val attributeEncoderContravariant: Contravariant[AttributeEncoder] =

--- a/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait AttributeLiteralInstances

--- a/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait ElementLiteralInstances

--- a/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait TextLiteralInstances

--- a/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/decoding/XmlDecoderIterable.scala
+++ b/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/decoding/XmlDecoderIterable.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import javax.xml.stream.XMLStreamConstants
-import ru.tinkoff.phobos.decoding.XmlDecoder.createStreamReader
+import phobos.decoding.XmlDecoder.createStreamReader
 
 trait XmlDecoderIterable[A] { xmlDecoder: XmlDecoder[A] =>
   def decodeFromIterable(

--- a/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/encoding/AttributeLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/encoding/AttributeLiteralInstances.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait AttributeLiteralInstances

--- a/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/encoding/ElementLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/encoding/ElementLiteralInstances.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait ElementLiteralInstances

--- a/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/encoding/TextLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.12/ru/tinkoff/phobos/encoding/TextLiteralInstances.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait TextLiteralInstances

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait AttributeLiteralInstances {
   implicit def literalDecoder[A, L <: A](

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait ElementLiteralInstances {
   implicit def literalDecoder[A, L <: A](implicit decoder: ElementDecoder[A], valueOfL: ValueOf[L]): ElementDecoder[L] =

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait TextLiteralInstances {
   implicit def literalDecoder[A, L <: A](implicit decoder: TextDecoder[A], valueOfL: ValueOf[L]): TextDecoder[L] =

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/XmlDecoderIterable.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/XmlDecoderIterable.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import javax.xml.stream.XMLStreamConstants
-import ru.tinkoff.phobos.decoding.XmlDecoder.createStreamReader
+import phobos.decoding.XmlDecoder.createStreamReader
 
 trait XmlDecoderIterable[A] { xmlDecoder: XmlDecoder[A] =>
   def decodeFromIterable(

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/encoding/AttributeLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/encoding/AttributeLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait AttributeLiteralInstances {
   implicit def literalEncoder[A, L <: A](

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/encoding/ElementLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/encoding/ElementLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait ElementLiteralInstances {
   implicit def literalEncoder[A, L <: A](implicit encoder: ElementEncoder[A], valueOfL: ValueOf[L]): ElementEncoder[L] =

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/encoding/TextLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/encoding/TextLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait TextLiteralInstances {
   implicit def literalEncoder[A, L <: A](implicit encoder: TextEncoder[A], valueOfL: ValueOf[L]): TextEncoder[L] =

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/CodecAnnotation.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/CodecAnnotation.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos.annotations
+package phobos.annotations
 
-import ru.tinkoff.phobos.configured.ElementCodecConfig
+import phobos.configured.ElementCodecConfig
 import scala.reflect.macros.blackbox
 
 private[phobos] abstract class CodecAnnotation(val c: blackbox.Context) {

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/ElementCodec.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/ElementCodec.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos.annotations
+package phobos.annotations
 
-import ru.tinkoff.phobos.configured.ElementCodecConfig
+import phobos.configured.ElementCodecConfig
 
 import scala.annotation.nowarn
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
@@ -15,7 +15,7 @@ private final class ElementCodecImpl(ctx: blackbox.Context) extends CodecAnnotat
   import c.universe._
 
   def instances(typ: Tree): Seq[Tree] = {
-    val pkg = q"ru.tinkoff.phobos"
+    val pkg = q"phobos"
 
     @nowarn("msg=not.*?exhaustive")
     val config = c.prefix.tree match {

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/XmlCodec.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/XmlCodec.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos.annotations
+package phobos.annotations
 
-import ru.tinkoff.phobos.configured.ElementCodecConfig
+import phobos.configured.ElementCodecConfig
 
 import scala.annotation.nowarn
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
@@ -15,7 +15,7 @@ private final class XmlCodecImpl(ctx: blackbox.Context) extends CodecAnnotation(
   import c.universe._
 
   def instances(typ: Tree): Seq[Tree] = {
-    val pkg = q"ru.tinkoff.phobos"
+    val pkg = q"phobos"
     val (localName, config) = (c.prefix.tree: @nowarn("msg=not.*?exhaustive")) match {
       case q"new XmlCodec($localName)"          => (localName, defaultConfig.tree)
       case q"new XmlCodec($localName, $config)" => (localName, config)

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/XmlCodecNs.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/XmlCodecNs.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.annotations
+package phobos.annotations
 
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.configured.ElementCodecConfig
+import phobos.Namespace
+import phobos.configured.ElementCodecConfig
 
 import scala.annotation.nowarn
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
@@ -18,7 +18,7 @@ private final class XmlCodecNsImpl(ctx: blackbox.Context) extends CodecAnnotatio
   import c.universe._
 
   def instances(typ: Tree): Seq[Tree] = {
-    val pkg = q"ru.tinkoff.phobos"
+    val pkg = q"phobos"
     val (nsInstance, localName, config) = (c.prefix.tree: @nowarn("msg=not.*?exhaustive")) match {
       case q"new XmlCodecNs($localName, $nsInstance)"              => (nsInstance, localName, defaultConfig.tree)
       case q"new XmlCodecNs($localName, $nsInstance, $config)"     => (nsInstance, localName, config)

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/XmlnsDef.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/annotations/XmlnsDef.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.annotations
+package phobos.annotations
 
 import scala.annotation.nowarn
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
@@ -14,7 +14,7 @@ private final class XmlnsDefImpl(ctx: blackbox.Context) extends CodecAnnotation(
 
   @nowarn("msg=not.*?exhaustive")
   def instances(typ: Tree): Seq[Tree] = {
-    val pkg          = q"ru.tinkoff.phobos"
+    val pkg          = q"phobos"
     val instanceName = TermName(c.freshName("namespaceInstance"))
     val (uri, useNameAsPrefix) = c.prefix.tree match {
       case q"new XmlnsDef($uri)"                   => (uri, q"false")

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/decoding/DerivedElement.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/decoding/DerivedElement.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait DerivedElement {}

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/CallByNeed.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/CallByNeed.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
 /*
  * Copy-pasted from https://github.com/propensive/magnolia

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/CompileTimeState.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/CompileTimeState.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
 /*
  * Copy-pasted from https://github.com/propensive/magnolia

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.decoding.{AttributeDecoder, ElementDecoder, TextDecoder}
-import ru.tinkoff.phobos.derivation.CompileTimeState.{CoproductType, ProductType, Stack}
+import phobos.Namespace
+import phobos.configured.ElementCodecConfig
+import phobos.decoding.{AttributeDecoder, ElementDecoder, TextDecoder}
+import phobos.derivation.CompileTimeState.{CoproductType, ProductType, Stack}
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -14,8 +14,8 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
 
   def searchType[T: c.WeakTypeTag]: Type = appliedType(c.typeOf[ElementDecoder[_]], c.weakTypeOf[T])
 
-  val derivationPkg = q"_root_.ru.tinkoff.phobos.derivation"
-  val decodingPkg   = q"_root_.ru.tinkoff.phobos.decoding"
+  val derivationPkg = q"_root_.phobos.derivation"
+  val decodingPkg   = q"_root_.phobos.decoding"
   val scalaPkg      = q"_root_.scala"
   val javaPkg       = q"_root_.java.lang"
 
@@ -391,7 +391,7 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
     xmlConfigured[T](localName, defaultConfig)
 
   def xmlConfigured[T: c.WeakTypeTag](localName: Tree, config: Expr[ElementCodecConfig]): Tree =
-    q"""_root_.ru.tinkoff.phobos.decoding.XmlDecoder.fromElementDecoder[${weakTypeOf[
+    q"""_root_.phobos.decoding.XmlDecoder.fromElementDecoder[${weakTypeOf[
         T,
       ]}]($localName)(${elementConfigured[T](config)})"""
 
@@ -406,7 +406,7 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
     val nsInstance = Option(c.inferImplicitValue(appliedType(weakTypeOf[Namespace[_]], weakTypeOf[NS])))
       .filter(_.nonEmpty)
       .getOrElse(error(s"Could not find Namespace instance for $ns"))
-    q"""_root_.ru.tinkoff.phobos.decoding.XmlDecoder.fromElementDecoderNs[${weakTypeOf[T]}, ${weakTypeOf[
+    q"""_root_.phobos.decoding.XmlDecoder.fromElementDecoderNs[${weakTypeOf[T]}, ${weakTypeOf[
         NS,
       ]}]($localName, $ns)(${elementConfigured[T](config)}, $nsInstance)"""
   }

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/Deferred.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/Deferred.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
 /*
  * Copy-pasted from https://github.com/propensive/magnolia

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/Derivation.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/Derivation.scala
@@ -1,10 +1,10 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.derivation.CompileTimeState.{ChainedImplicit, Stack}
-import ru.tinkoff.phobos.derivation.Derivation.DirectlyReentrantException
-import ru.tinkoff.phobos.syntax.{xmlns, default, attr, renamed, text, discriminator}
+import phobos.Namespace
+import phobos.configured.ElementCodecConfig
+import phobos.derivation.CompileTimeState.{ChainedImplicit, Stack}
+import phobos.derivation.Derivation.DirectlyReentrantException
+import phobos.syntax.{xmlns, default, attr, renamed, text, discriminator}
 
 import scala.annotation.nowarn
 import scala.reflect.macros.blackbox
@@ -58,7 +58,7 @@ private[phobos] abstract class Derivation(val c: blackbox.Context) {
     val searchType = appliedType(typeConstructor, genericType)
     val deferredRef = for (methodName <- stack find searchType) yield {
       val methodAsString = methodName.decodedName.toString
-      q"_root_.ru.tinkoff.phobos.derivation.Deferred.apply[$searchType]($methodAsString)"
+      q"_root_.phobos.derivation.Deferred.apply[$searchType]($methodAsString)"
     }
 
     deferredRef.getOrElse {
@@ -96,7 +96,7 @@ private[phobos] abstract class Derivation(val c: blackbox.Context) {
 
     val expandDeferred = new Transformer {
       override def transform(tree: Tree) = tree match {
-        case q"_root_.ru.tinkoff.phobos.derivation.Deferred.apply[$_](${Literal(Constant(method: String))})" =>
+        case q"_root_.phobos.derivation.Deferred.apply[$_](${Literal(Constant(method: String))})" =>
           q"${TermName(method)}"
         case _ =>
           super.transform(tree)
@@ -218,7 +218,7 @@ private[phobos] abstract class Derivation(val c: blackbox.Context) {
 
     val result = stack
       .find(searchType)
-      .map(enclosingRef => q"_root_.ru.tinkoff.phobos.derivation.Deferred[$searchType](${enclosingRef.toString})")
+      .map(enclosingRef => q"_root_.phobos.derivation.Deferred[$searchType](${enclosingRef.toString})")
       .getOrElse(inferCodec)
 
     if (stack.nonEmpty) result

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/EncoderDerivation.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/EncoderDerivation.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.derivation.CompileTimeState.{CoproductType, ProductType, Stack}
-import ru.tinkoff.phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder}
+import phobos.Namespace
+import phobos.configured.ElementCodecConfig
+import phobos.derivation.CompileTimeState.{CoproductType, ProductType, Stack}
+import phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder}
 
 import scala.collection.mutable.ListBuffer
 import scala.reflect.macros.blackbox
@@ -52,10 +52,10 @@ class EncoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
     q"""
       ..$preAssignments
 
-      new _root_.ru.tinkoff.phobos.encoding.ElementEncoder[$classType] {
+      new _root_.phobos.encoding.ElementEncoder[$classType] {
         def encodeAsElement(
           a: $classType,
-          sw: _root_.ru.tinkoff.phobos.encoding.PhobosStreamWriter,
+          sw: _root_.phobos.encoding.PhobosStreamWriter,
           localName: $javaPkg.String,
           namespaceUri: $scalaPkg.Option[$javaPkg.String],
           preferredNamespacePrefix: $scalaPkg.Option[$javaPkg.String],
@@ -129,10 +129,10 @@ class EncoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
     q"""
      ..$preAssignments
 
-     new _root_.ru.tinkoff.phobos.encoding.ElementEncoder[$classType] {
+     new _root_.phobos.encoding.ElementEncoder[$classType] {
        def encodeAsElement(
          a: $classType,
-         sw: _root_.ru.tinkoff.phobos.encoding.PhobosStreamWriter,
+         sw: _root_.phobos.encoding.PhobosStreamWriter,
          localName: $javaPkg.String,
          namespaceUri: $scalaPkg.Option[$javaPkg.String],
          preferredNamespacePrefix: $scalaPkg.Option[$javaPkg.String],
@@ -162,7 +162,7 @@ class EncoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
     xmlConfigured[T](localName, defaultConfig)
 
   def xmlConfigured[T: c.WeakTypeTag](localName: Tree, config: Expr[ElementCodecConfig]): Tree =
-    q"""_root_.ru.tinkoff.phobos.encoding.XmlEncoder.fromElementEncoder[${weakTypeOf[
+    q"""_root_.phobos.encoding.XmlEncoder.fromElementEncoder[${weakTypeOf[
         T,
       ]}]($localName)(${elementConfigured[T](config)})"""
 
@@ -177,7 +177,7 @@ class EncoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
     val nsInstance = Option(c.inferImplicitValue(appliedType(weakTypeOf[Namespace[_]], weakTypeOf[NS])))
       .filter(_.nonEmpty)
       .getOrElse(error(s"Could not find Namespace instance for $ns"))
-    q"""_root_.ru.tinkoff.phobos.encoding.XmlEncoder.fromElementEncoderNs[${weakTypeOf[T]}, ${weakTypeOf[
+    q"""_root_.phobos.encoding.XmlEncoder.fromElementEncoderNs[${weakTypeOf[T]}, ${weakTypeOf[
         NS,
       ]}]($localName, $ns)(${elementConfigured[T](config)}, $nsInstance)"""
   }

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/ExportMacro.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/ExportMacro.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.decoding.ElementDecoder
-import ru.tinkoff.phobos.encoding.ElementEncoder
+import phobos.decoding.ElementDecoder
+import phobos.encoding.ElementEncoder
 
 import scala.reflect.macros.blackbox
 
@@ -9,14 +9,14 @@ class ExportMacro(val c: blackbox.Context) {
   import c.universe._
 
   def exportEncoder[A: WeakTypeTag]: Expr[Exported[ElementEncoder[A]]] = {
-    c.Expr[Exported[ElementEncoder[A]]](q"""new _root_.ru.tinkoff.phobos.derivation.Exported(
-       _root_.ru.tinkoff.phobos.derivation.semiauto.deriveElementEncoder[${weakTypeOf[A]}]
+    c.Expr[Exported[ElementEncoder[A]]](q"""new _root_.phobos.derivation.Exported(
+       _root_.phobos.derivation.semiauto.deriveElementEncoder[${weakTypeOf[A]}]
      )""")
   }
 
   def exportDecoder[A: WeakTypeTag]: Expr[Exported[ElementDecoder[A]]] = {
-    c.Expr[Exported[ElementDecoder[A]]](q"""new _root_.ru.tinkoff.phobos.derivation.Exported(
-       _root_.ru.tinkoff.phobos.derivation.semiauto.deriveElementDecoder[${weakTypeOf[A]}]
+    c.Expr[Exported[ElementDecoder[A]]](q"""new _root_.phobos.derivation.Exported(
+       _root_.phobos.derivation.semiauto.deriveElementDecoder[${weakTypeOf[A]}]
      )""")
   }
 }

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/Exported.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/Exported.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
 class Exported[T](val value: T)

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/ParamCategory.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/ParamCategory.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
 sealed trait ParamCategory
 

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/auto/package.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/auto/package.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.encoding.ElementEncoder
-import ru.tinkoff.phobos.decoding.ElementDecoder
+import phobos.encoding.ElementEncoder
+import phobos.decoding.ElementDecoder
 
 /** Importing contents of this package will provide ElementEncoder / ElementDecoder instances for any case class. It may
   * be useful while researching, however do not use this in production, because automatic derivation is less performant

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/semiauto/semiauto.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/semiauto/semiauto.scala
@@ -1,8 +1,8 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.decoding.{ElementDecoder, XmlDecoder}
-import ru.tinkoff.phobos.encoding.{ElementEncoder, XmlEncoder}
-import ru.tinkoff.phobos.configured._
+import phobos.decoding.{ElementDecoder, XmlDecoder}
+import phobos.encoding.{ElementEncoder, XmlEncoder}
+import phobos.configured._
 
 package object semiauto {
 
@@ -15,7 +15,7 @@ package object semiauto {
     *   - children elements, if they do not have these annotations (implicit ElementEncoder is infered)
     *
     * Namespaces of elements and attributes are defined with @xmlns(nsi) annotation. In this case "nsi" inside @xmlns
-    * annotation is some case object with existing implicit ru.tinkoff.phobos.Namespace[nsi.type] instance.
+    * annotation is some case object with existing implicit phobos.Namespace[nsi.type] instance.
     */
   def deriveElementEncoder[T]: ElementEncoder[T] = macro EncoderDerivation.element[T]
 
@@ -53,7 +53,7 @@ package object semiauto {
     *   - children elements, if they do not have these annotations (implicit ElementDecoder is infered)
     *
     * Namespaces of elements and attributes are defined with @xmlns(nsi) annotation. In this case "nsi" inside @xmlns
-    * annotation is some case object with existing implicit ru.tinkoff.phobos.Namespace[nsi.type] instance.
+    * annotation is some case object with existing implicit phobos.Namespace[nsi.type] instance.
     */
   def deriveElementDecoder[T]: ElementDecoder[T] = macro DecoderDerivation.element[T]
 

--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/encoding/DerivedElement.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/encoding/DerivedElement.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait DerivedElement {}

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait AttributeLiteralInstances {
   implicit def literalDecoder[A, L <: A](

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/DerivedElement.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/DerivedElement.scala
@@ -1,8 +1,8 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.derivation.decoder
-import ru.tinkoff.phobos.derivation.LazySummon
+import phobos.configured.ElementCodecConfig
+import phobos.derivation.decoder
+import phobos.derivation.LazySummon
 import scala.deriving.Mirror
 
 private[decoding] trait DerivedElement {

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait ElementLiteralInstances {
   implicit def literalDecoder[A, L <: A](implicit decoder: ElementDecoder[A], valueOfL: ValueOf[L]): ElementDecoder[L] =

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 private[decoding] trait TextLiteralInstances {
   implicit def literalDecoder[A, L <: A](implicit decoder: TextDecoder[A], valueOfL: ValueOf[L]): TextDecoder[L] =

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/XmlDecoderIterable.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/XmlDecoderIterable.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import javax.xml.stream.XMLStreamConstants
-import ru.tinkoff.phobos.decoding.XmlDecoder.createStreamReader
+import phobos.decoding.XmlDecoder.createStreamReader
 
 trait XmlDecoderIterable[A] { xmlDecoder: XmlDecoder[A] =>
   def decodeFromIterable(

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/Exported.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/Exported.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
 class Exported[T](val value: T)

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/LazySummon.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/LazySummon.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
 /** Defining givens of such type in companion objects of ElementEncoder and ElementDecoder allows to summon instances of
   * these typeclasses for every child of a sum type (sealed trait or enum), e.g. like this:

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/auto/package.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/auto/package.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.decoding.ElementDecoder
-import ru.tinkoff.phobos.encoding.ElementEncoder
+import phobos.decoding.ElementDecoder
+import phobos.encoding.ElementEncoder
 
 package object auto {
   inline implicit def deriveExportedEncoder[A]: Exported[ElementEncoder[A]] =

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/common.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/common.scala
@@ -1,8 +1,8 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.syntax.*
+import phobos.Namespace
+import phobos.configured.ElementCodecConfig
+import phobos.syntax.*
 
 import scala.quoted.*
 import scala.compiletime.*

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/decoder.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/decoder.scala
@@ -1,13 +1,13 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
 import com.fasterxml.aalto.AsyncXMLStreamReader
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.decoding.*
-import ru.tinkoff.phobos.decoding.ElementDecoder.{ConstDecoder, FailedDecoder}
-import ru.tinkoff.phobos.derivation.common.*
-import ru.tinkoff.phobos.derivation.decoder.DecoderState.IgnoringElement
-import ru.tinkoff.phobos.syntax.*
+import phobos.Namespace
+import phobos.configured.ElementCodecConfig
+import phobos.decoding.*
+import phobos.decoding.ElementDecoder.{ConstDecoder, FailedDecoder}
+import phobos.derivation.common.*
+import phobos.derivation.decoder.DecoderState.IgnoringElement
+import phobos.syntax.*
 
 import scala.annotation.nowarn
 import scala.annotation.tailrec

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/encoder.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/encoder.scala
@@ -1,10 +1,10 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.syntax.*
-import ru.tinkoff.phobos.encoding.*
-import ru.tinkoff.phobos.derivation.common.*
+import phobos.Namespace
+import phobos.configured.ElementCodecConfig
+import phobos.syntax.*
+import phobos.encoding.*
+import phobos.derivation.common.*
 
 import scala.annotation.nowarn
 import scala.compiletime.*

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/semiauto/package.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/semiauto/package.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.derivation
+package phobos.derivation
 
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.decoding.{ElementDecoder, XmlDecoder}
-import ru.tinkoff.phobos.encoding.{ElementEncoder, XmlEncoder}
+import phobos.Namespace
+import phobos.configured.ElementCodecConfig
+import phobos.decoding.{ElementDecoder, XmlDecoder}
+import phobos.encoding.{ElementEncoder, XmlEncoder}
 
 package object semiauto {
   inline def deriveElementEncoder[T]: ElementEncoder[T] =

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/encoding/AttributeLiteralInstances.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/encoding/AttributeLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait AttributeLiteralInstances {
   implicit def literalEncoder[A, L <: A](

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/encoding/DerivedElement.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/encoding/DerivedElement.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.derivation.encoder
+import phobos.configured.ElementCodecConfig
+import phobos.derivation.encoder
 import scala.deriving.Mirror
-import ru.tinkoff.phobos.derivation.LazySummon
+import phobos.derivation.LazySummon
 
 private[encoding] trait DerivedElement {
   inline def derived[T]: ElementEncoder[T] =

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/encoding/ElementLiteralInstances.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/encoding/ElementLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait ElementLiteralInstances {
   implicit def literalEncoder[A, L <: A](implicit encoder: ElementEncoder[A], valueOfL: ValueOf[L]): ElementEncoder[L] =

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/encoding/TextLiteralInstances.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/encoding/TextLiteralInstances.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 private[encoding] trait TextLiteralInstances {
   implicit def literalEncoder[A, L <: A](implicit encoder: TextEncoder[A], valueOfL: ValueOf[L]): TextEncoder[L] =

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/Namespace.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/Namespace.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos
+package phobos
 
 /** Typeclass for defining XML namespaces.
   *

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/configured/ElementCodecConfig.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/configured/ElementCodecConfig.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos.configured
+package phobos.configured
 
-import ru.tinkoff.phobos.Namespace
+import phobos.Namespace
 
 /** Config, that can modify the behaviour of derived element decoders and encoders.
   *

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/configured/naming.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/configured/naming.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.configured
+package phobos.configured
 
 object naming {
   val camelCase: String => String = _.capitalize

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/AttributeDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/AttributeDecoder.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import java.time._
 import java.time.format.DateTimeFormatter

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/Cursor.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/Cursor.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import java.io.Writer
 import java.math.{BigDecimal, BigInteger}

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/DecodingError.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/DecodingError.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 case class DecodingError(text: String, history: List[String], cause: Option[Throwable])
     extends Exception(cause.orNull) {

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/ElementDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/ElementDecoder.scala
@@ -1,11 +1,11 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import java.time._
 import java.util.{Base64, UUID}
 
 import com.fasterxml.aalto.AsyncXMLStreamReader
 import javax.xml.stream.XMLStreamConstants
-import ru.tinkoff.phobos.decoding.ElementDecoder.{EMappedDecoder, MappedDecoder}
+import phobos.decoding.ElementDecoder.{EMappedDecoder, MappedDecoder}
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
@@ -20,7 +20,7 @@ import java.time.format.DateTimeFormatter
   *
   * ElementDecoder instance can be created
   *   - from existing instance by using .map or .emap method (mostly used for "simple" types);
-  *   - by macros from ru.tinkoff.phobos.derivation.semiauto package (for case classes and sealed traits).
+  *   - by macros from phobos.derivation.semiauto package (for case classes and sealed traits).
   *
   * This typeclass describes process of decoding some element to an A value. Name of the element is not defined in
   * typeclass, it should be passed in decodeAsElement method.

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/TextDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/TextDecoder.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import java.time._
 import java.util.{Base64, UUID}
 import javax.xml.stream.XMLStreamConstants
-import ru.tinkoff.phobos.decoding.TextDecoder.{EMappedDecoder, MappedDecoder}
+import phobos.decoding.TextDecoder.{EMappedDecoder, MappedDecoder}
 
 import java.time.format.DateTimeFormatter
 import scala.annotation.tailrec

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
@@ -1,11 +1,11 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import javax.xml.stream.XMLStreamConstants
 import com.fasterxml.aalto.AsyncByteArrayFeeder
 import com.fasterxml.aalto.async.{AsyncByteArrayScanner, AsyncStreamReaderImpl}
 import com.fasterxml.aalto.stax.InputFactoryImpl
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.decoding.XmlDecoder.createStreamReader
+import phobos.Namespace
+import phobos.decoding.XmlDecoder.createStreamReader
 
 /** Typeclass for decoding XML document to an A value.
   *
@@ -13,7 +13,7 @@ import ru.tinkoff.phobos.decoding.XmlDecoder.createStreamReader
   *
   * XmlDecoder instance can be created
   *   - from ElementDecoder using functions in XmlDecoder object
-  *   - by macros from ru.tinkoff.phobos.derivation.semiauto package
+  *   - by macros from phobos.derivation.semiauto package
   *
   * This typeclass wraps ElementDecoder[A] and provides element name and Cursor.
   */

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/package.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/package.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos
+package phobos
 
 import com.fasterxml.aalto.{AsyncByteArrayFeeder, AsyncXMLStreamReader}
 

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/AttributeEncoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/AttributeEncoder.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 import java.time._
 import java.time.format.DateTimeFormatter

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/ElementEncoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/ElementEncoder.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 import java.time._
 import java.util.{Base64, UUID}
@@ -13,7 +13,7 @@ import java.time.format.DateTimeFormatter
   *
   * ElementEncoder instance can be created
   *   - from existing instance by using .contramap (mostly used for "simple" types);
-  *   - by macros from ru.tinkoff.phobos.derivation.semiauto package (for case classes and sealed traits).
+  *   - by macros from phobos.derivation.semiauto package (for case classes and sealed traits).
   *
   * This typeclass describes process of encoding some A value to XML document. Name of the element is not defined in
   * typeclass, it should be passed in encodeAsElement method.

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/EncodingError.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/EncodingError.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 case class EncodingError(text: String, cause: Option[Throwable] = None) extends Exception(text, cause.orNull) {
   override def getMessage: String = s"Error while encoding XML: $text"

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/PhobosStreamWriter.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/PhobosStreamWriter.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 import java.math.BigInteger
 import javax.xml.namespace.{NamespaceContext, QName}

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/TextEncoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/TextEncoder.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 import java.time._
 import java.time.format.DateTimeFormatter

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/XmlEncoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/XmlEncoder.scala
@@ -1,12 +1,12 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 import java.io.{ByteArrayOutputStream, StringReader, StringWriter}
 import javax.xml.transform._
 import javax.xml.transform.stream._
 import com.fasterxml.aalto.stax.OutputFactoryImpl
 import org.codehaus.stax2.XMLStreamWriter2
-import ru.tinkoff.phobos.Namespace
-import ru.tinkoff.phobos.encoding.XmlEncoder.XmlEncoderConfig
+import phobos.Namespace
+import phobos.encoding.XmlEncoder.XmlEncoderConfig
 
 /** Typeclass for encoding XML document to an A value.
   *
@@ -14,7 +14,7 @@ import ru.tinkoff.phobos.encoding.XmlEncoder.XmlEncoderConfig
   *
   * XmlEncoder instance can be created
   *   - from ElementEncoder using functions in XmlEncoder object
-  *   - by macros from ru.tinkoff.phobos.derivation.semiauto package
+  *   - by macros from phobos.derivation.semiauto package
   *
   * This typeclass wraps ElementEncoder[A] and provides element name and StreamWriter.
   */

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/syntax.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/syntax.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos
+package phobos
 import scala.annotation.StaticAnnotation
 
-/** Syntax annotations for case class params. See ru.tinkoff.derivation.semiato docs for more explanation.
+/** Syntax annotations for case class params. See phobos.derivation.semiato docs for more explanation.
   */
 object syntax {
 

--- a/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralDecodingTest.scala
+++ b/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralDecodingTest.scala
@@ -1,11 +1,11 @@
-package ru.tinkoff.phobos
+package phobos
 
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.annotations.XmlCodec
-import ru.tinkoff.phobos.decoding.{DecodingError, XmlDecoder}
-import ru.tinkoff.phobos.syntax.{attr, text}
+import phobos.annotations.XmlCodec
+import phobos.decoding.{DecodingError, XmlDecoder}
+import phobos.syntax.{attr, text}
 
 class LiteralDecodingTest extends AnyWordSpec with Matchers {
   def pure(str: String): List[Array[Byte]] =

--- a/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralEncodingTest.scala
+++ b/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralEncodingTest.scala
@@ -1,10 +1,10 @@
-package ru.tinkoff.phobos
+package phobos
 
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.annotations.XmlCodec
-import ru.tinkoff.phobos.encoding.XmlEncoder
-import ru.tinkoff.phobos.syntax.{attr, text}
-import ru.tinkoff.phobos.testString._
+import phobos.annotations.XmlCodec
+import phobos.encoding.XmlEncoder
+import phobos.syntax.{attr, text}
+import phobos.testString._
 
 class LiteralEncodingTest extends AnyWordSpec {
   "Literal encoders" should {

--- a/modules/core/src/test/scala-3/ru/tinkoff/phobos/DerivationTest.scala
+++ b/modules/core/src/test/scala-3/ru/tinkoff/phobos/DerivationTest.scala
@@ -1,20 +1,20 @@
-package ru.tinkoff.phobos
+package phobos
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.decoding._
-import ru.tinkoff.phobos.encoding._
-import ru.tinkoff.phobos.testString._
-import ru.tinkoff.phobos.syntax.discriminator
-import ru.tinkoff.phobos.syntax.text
-import ru.tinkoff.phobos.syntax.attr
-import ru.tinkoff.phobos.SealedClasses.Animal.animalDecoder
-import ru.tinkoff.phobos.derivation.LazySummon
+import phobos.decoding._
+import phobos.encoding._
+import phobos.testString._
+import phobos.syntax.discriminator
+import phobos.syntax.text
+import phobos.syntax.attr
+import phobos.SealedClasses.Animal.animalDecoder
+import phobos.derivation.LazySummon
 import scala.reflect.TypeTest
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.derivation.common.extractSumTypeChild
-import ru.tinkoff.phobos.derivation.semiauto.deriveXmlEncoder
-import ru.tinkoff.phobos.derivation.encoder.deriveElementEncoder
+import phobos.configured.ElementCodecConfig
+import phobos.derivation.common.extractSumTypeChild
+import phobos.derivation.semiauto.deriveXmlEncoder
+import phobos.derivation.encoder.deriveElementEncoder
 import scala.deriving.Mirror
 import scala.annotation.nowarn
 

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/AutoDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/AutoDerivationTest.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos
+package phobos
 
-import ru.tinkoff.phobos.testString._
+import phobos.testString._
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -8,10 +8,10 @@ class AutoDerivationTest extends AnyWordSpec with Matchers {
   "Automatic derivation" should {
     "derive codecs" in {
       """
-         import ru.tinkoff.phobos.encoding._
-         import ru.tinkoff.phobos.decoding._
-         import ru.tinkoff.phobos.syntax._
-         import ru.tinkoff.phobos.derivation.auto._
+         import phobos.encoding._
+         import phobos.decoding._
+         import phobos.syntax._
+         import phobos.derivation.auto._
 
          case class Foo(@attr bar: Int, @attr baz: Double, @text txt: String)
          case class Bar(@attr quxx: Float, foo: Foo, qux: Byte)
@@ -23,8 +23,8 @@ class AutoDerivationTest extends AnyWordSpec with Matchers {
 
     "not derive encoder if not imported" in {
       """
-         import ru.tinkoff.phobos.encoding._
-         import ru.tinkoff.phobos.syntax._
+         import phobos.encoding._
+         import phobos.syntax._
          case class Foo(@attr bar: Int, @attr baz: Double, @text txt: String)
          case class Bar(@attr quxx: Float, foo: Foo, qux: Byte)
 
@@ -34,8 +34,8 @@ class AutoDerivationTest extends AnyWordSpec with Matchers {
 
     "not derive decoder if not imported" in {
       """
-         import ru.tinkoff.phobos.decoding._
-         import ru.tinkoff.phobos.syntax._
+         import phobos.decoding._
+         import phobos.syntax._
 
          case class Foo(@attr bar: Int, @attr baz: Double, @text txt: String)
          case class Bar(@attr quxx: Float, foo: Foo, qux: Byte)
@@ -45,10 +45,10 @@ class AutoDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "derive codecs correctly" in {
-      import ru.tinkoff.phobos.syntax._
-      import ru.tinkoff.phobos.decoding._
-      import ru.tinkoff.phobos.encoding._
-      import ru.tinkoff.phobos.derivation.auto._
+      import phobos.syntax._
+      import phobos.decoding._
+      import phobos.encoding._
+      import phobos.derivation.auto._
 
       case class Foo(@attr bar: Int, @attr baz: Double, @text txt: String)
       case class Bar(foo: Float)

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationTest.scala
@@ -1,14 +1,14 @@
-package ru.tinkoff.phobos
+package phobos
 
 import org.scalatest.Assertion
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
-import ru.tinkoff.phobos.SealedClasses.{Animal, Cat, Cow, Dog}
-import ru.tinkoff.phobos.decoding.{AttributeDecoder, DecodingError, ElementDecoder, TextDecoder, XmlDecoder}
-import ru.tinkoff.phobos.syntax._
-import ru.tinkoff.phobos.configured.naming._
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.derivation.semiauto._
+import phobos.SealedClasses.{Animal, Cat, Cow, Dog}
+import phobos.decoding.{AttributeDecoder, DecodingError, ElementDecoder, TextDecoder, XmlDecoder}
+import phobos.syntax._
+import phobos.configured.naming._
+import phobos.configured.ElementCodecConfig
+import phobos.derivation.semiauto._
 
 import scala.annotation.nowarn
 
@@ -879,7 +879,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       val string4 = """<?xml version='1.0' encoding='UTF-8'?>
                       | <quux>
                       |   <d>d value</d>
-                      |   <baz xmlns:ans1="https://tinkoff.ru" ans1:discriminator="Baz1">
+                      |   <baz xmlns:ans1="https://example.org" ans1:discriminator="Baz1">
                       |     <a>string</a>
                       |   </baz>
                       |   <e>k</e>
@@ -888,7 +888,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       val string5 = """<?xml version='1.0' encoding='UTF-8'?>
                       | <quux>
                       |   <d>d value</d>
-                      |   <baz xmlns:ans1="https://tinkoff.ru" ans1:discriminator="Baz2">
+                      |   <baz xmlns:ans1="https://example.org" ans1:discriminator="Baz2">
                       |     <b>1</b>
                       |   </baz>
                       |   <e>e</e>
@@ -897,7 +897,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       val string6 = """<?xml version='1.0' encoding='UTF-8'?>
                       | <quux>
                       |   <d>another one value</d>
-                      |   <baz xmlns:ans1="https://tinkoff.ru" ans1:discriminator="Baz3">
+                      |   <baz xmlns:ans1="https://example.org" ans1:discriminator="Baz3">
                       |     <c>1.1234</c>
                       |   </baz>
                       |   <e>v</e>
@@ -1073,26 +1073,26 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
   "Decoder derivation with namespaces" should {
 
     def decodeSimpleCaseClasses(toList: String => List[Array[Byte]]): Assertion = {
-      object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
       case class Foo(
-          @xmlns(tkf) a: Int,
-          @xmlns(tkf) b: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) a: Int,
+          @xmlns(org) b: String,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tkf) d: String,
-          @xmlns(tkf) foo: Foo,
-          @xmlns(tkf) e: Char,
+          @xmlns(org) d: String,
+          @xmlns(org) foo: Foo,
+          @xmlns(org) e: Char,
       )
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoder
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoder("bar", tkf)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoder("bar", org)
 
       val bar = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = """<?xml version='1.0' encoding='UTF-8'?>
-                     | <ans1:bar xmlns:ans1="tinkoff.ru">
+                     | <ans1:bar xmlns:ans1="example.org">
                      |   <ans1:d>d value</ans1:d>
                      |   <ans1:foo>
                      |     <ans1:a>1</ans1:a>
@@ -1111,26 +1111,26 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
     "decode simple case classes async" in decodeSimpleCaseClasses(fromIterable)
 
     def decodeAttributes(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
       case class Foo(
-          @xmlns(tkf) a: Int,
-          @xmlns(tkf) @attr b: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) a: Int,
+          @xmlns(org) @attr b: String,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tkf) d: String,
-          @xmlns(tkf) foo: Foo,
-          @xmlns(tkf) @attr e: Char,
+          @xmlns(org) d: String,
+          @xmlns(org) foo: Foo,
+          @xmlns(org) @attr e: Char,
       )
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoder
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoder("bar", tkf)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoder("bar", org)
 
       val bar = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = """<?xml version='1.0' encoding='UTF-8'?>
-                     | <ans1:bar xmlns:ans1="tinkoff.ru" ans1:e="e">
+                     | <ans1:bar xmlns:ans1="example.org" ans1:e="e">
                      |   <ans1:d>d value</ans1:d>
                      |   <ans1:foo ans1:b="b value">
                      |     <ans1:a>1</ans1:a>
@@ -1148,16 +1148,16 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
     "decode attributes async" in decodeAttributes(fromIterable)
 
     def decodeNestedNamespaces(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
       case class Foo(
-          @xmlns(tkf) a: Int,
+          @xmlns(org) a: Int,
           @attr b: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) c: Double,
       )
       case class Bar(
           d: String,
-          @xmlns(tkf) foo: Foo,
+          @xmlns(org) foo: Foo,
           @attr e: Char,
       )
 
@@ -1168,7 +1168,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       val string = """<?xml version='1.0' encoding='UTF-8'?>
                      | <bar e="e">
                      |   <d>d value</d>
-                     |   <ans1:foo xmlns:ans1="tinkoff.ru" b="b value">
+                     |   <ans1:foo xmlns:ans1="example.org" b="b value">
                      |     <ans1:a>1</ans1:a>
                      |     <ans1:c>3.0</ans1:c>
                      |   </ans1:foo>
@@ -1183,30 +1183,30 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
     "decode nested namespaces async" in decodeNestedNamespaces(fromIterable)
 
     def decodeMultipleNamespaces(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
       case class Foo(
-          @xmlns(tkf) a: Int,
+          @xmlns(org) a: Int,
           @attr b: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tcs) d: String,
-          @xmlns(tkf) foo: Foo,
+          @xmlns(com) d: String,
+          @xmlns(org) foo: Foo,
           @attr e: Char,
       )
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoder
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoder("bar", tcs)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoder("bar", com)
 
       val bar = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = """<?xml version='1.0' encoding='UTF-8'?>
-                     | <ans1:bar xmlns:ans1="tcsbank.ru" e="e">
+                     | <ans1:bar xmlns:ans1="example.com" e="e">
                      |   <ans1:d>d value</ans1:d>
-                     |   <ans2:foo xmlns:ans2="tinkoff.ru" b="b value">
+                     |   <ans2:foo xmlns:ans2="example.org" b="b value">
                      |     <ans2:a>1</ans2:a>
                      |     <ans2:c>3.0</ans2:c>
                      |   </ans2:foo>
@@ -1223,24 +1223,24 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
 
     def decodeCamelCase(toList: String => List[Array[Byte]]): Assertion = {
       val camelCaseConfig = ElementCodecConfig.default.withFieldNamesTransformed(camelCase)
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
       case class Foo(
-          @xmlns(tkf) someName: Int,
-          @xmlns(tkf) someOtherName: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) someName: Int,
+          @xmlns(org) someOtherName: String,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tkf) someTopName: String,
-          @xmlns(tkf) someFoo: Foo,
+          @xmlns(org) someTopName: String,
+          @xmlns(org) someFoo: Foo,
       )
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoderConfigured(camelCaseConfig)
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("Bar", tkf, camelCaseConfig)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("Bar", org, camelCaseConfig)
 
       val bar = Bar("d value", Foo(1, "b value", 3.0))
       val string = """<?xml version='1.0' encoding='UTF-8'?>
-                     | <ans1:Bar xmlns:ans1="tinkoff.ru">
+                     | <ans1:Bar xmlns:ans1="example.org">
                      |   <ans1:SomeTopName>d value</ans1:SomeTopName>
                      |   <ans1:SomeFoo>
                      |     <ans1:SomeName>1</ans1:SomeName>
@@ -1259,25 +1259,25 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
 
     def decodeSnakeCase(toList: String => List[Array[Byte]]): Assertion = {
       val snakeCaseConfig = ElementCodecConfig.default.withFieldNamesTransformed(snakeCase)
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
       case class Foo(
-          @xmlns(tkf) someName: Int,
-          @xmlns(tkf) someOtherName: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) someName: Int,
+          @xmlns(org) someOtherName: String,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tkf) someTopName: String,
-          @xmlns(tkf) someFoo: Foo,
+          @xmlns(org) someTopName: String,
+          @xmlns(org) someFoo: Foo,
       )
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoderConfigured(snakeCaseConfig)
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", tkf, snakeCaseConfig)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", org, snakeCaseConfig)
 
       val bar = Bar("d value", Foo(1, "b value", 3.0))
       val string = """<?xml version='1.0' encoding='UTF-8'?>
-                     | <ans1:bar xmlns:ans1="tinkoff.ru">
+                     | <ans1:bar xmlns:ans1="example.org">
                      |   <ans1:some_top_name>d value</ans1:some_top_name>
                      |   <ans1:some_foo>
                      |     <ans1:some_name>1</ans1:some_name>
@@ -1295,20 +1295,20 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
     "decode snake_case async" in decodeSnakeCase(fromIterable)
 
     def decodeWithDefaultElementNamespaces(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      val defaultNamespaceConfig = ElementCodecConfig.default.withElementsDefaultNamespace(tkf)
+      val defaultNamespaceConfig = ElementCodecConfig.default.withElementsDefaultNamespace(org)
       case class Foo(a: Int, b: String, c: Double)
       case class Bar(@attr d: String, foo: Foo, e: Char)
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoder
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", tkf, defaultNamespaceConfig)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", org, defaultNamespaceConfig)
 
       val bar = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <ans1:bar xmlns:ans1="tinkoff.ru" d="d value">
+          | <ans1:bar xmlns:ans1="example.org" d="d value">
           |   <ans1:foo>
           |     <a>1</a>
           |     <b>b value</b>
@@ -1326,23 +1326,23 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
     "decode with default element namespaces async" in decodeWithDefaultElementNamespaces(fromIterable)
 
     def overrideDefaultElementNamespaceWithNamespaceFromAnnotation(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
-      val defaultNamespaceConfig = ElementCodecConfig.default.withElementsDefaultNamespace(tkf)
+      val defaultNamespaceConfig = ElementCodecConfig.default.withElementsDefaultNamespace(org)
       case class Foo(a: Int, b: String, c: Double)
-      case class Bar(@attr d: String, @xmlns(tcs) foo: Foo, e: Char)
+      case class Bar(@attr d: String, @xmlns(com) foo: Foo, e: Char)
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoder
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", tkf, defaultNamespaceConfig)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", org, defaultNamespaceConfig)
 
       val bar = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <ans1:bar xmlns:ans1="tinkoff.ru" d="d value">
-          |   <ans2:foo xmlns:ans2="tcsbank.ru">
+          | <ans1:bar xmlns:ans1="example.org" d="d value">
+          |   <ans2:foo xmlns:ans2="example.com">
           |     <a>1</a>
           |     <b>b value</b>
           |     <c>3.0</c>
@@ -1362,20 +1362,20 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       overrideDefaultElementNamespaceWithNamespaceFromAnnotation(fromIterable)
 
     def decodeWithDefaultAttributeNamespaces(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      val defaultNamespaceConfig = ElementCodecConfig.default.withAttributesDefaultNamespace(tkf)
+      val defaultNamespaceConfig = ElementCodecConfig.default.withAttributesDefaultNamespace(org)
       case class Foo(a: Int, b: String, c: Double)
       case class Bar(@attr d: String, foo: Foo, @attr e: Char)
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoder
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", tkf, defaultNamespaceConfig)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", org, defaultNamespaceConfig)
 
       val bar = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string =
         """<?xml version='1.0' encoding='UTF-8'?>
-        | <ans1:bar xmlns:ans1="tinkoff.ru" ans1:d="d value" ans1:e="e">
+        | <ans1:bar xmlns:ans1="example.org" ans1:d="d value" ans1:e="e">
         |   <foo>
         |     <a>1</a>
         |     <b>b value</b>
@@ -1392,22 +1392,22 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
     "decode with default attribute namespaces async" in decodeWithDefaultAttributeNamespaces(fromIterable)
 
     def overrideDefaultAttributeNamespaceWithNamespaceFromAnnotation(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
-      val defaultNamespaceConfig = ElementCodecConfig.default.withAttributesDefaultNamespace(tkf)
+      val defaultNamespaceConfig = ElementCodecConfig.default.withAttributesDefaultNamespace(org)
       case class Foo(a: Int, b: String, c: Double)
-      case class Bar(@attr d: String, foo: Foo, @attr @xmlns(tcs) e: Char)
+      case class Bar(@attr d: String, foo: Foo, @attr @xmlns(com) e: Char)
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoder
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", tkf, defaultNamespaceConfig)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoderConfigured("bar", org, defaultNamespaceConfig)
 
       val bar = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <ans1:bar xmlns:ans1="tinkoff.ru" ans1:d="d value" xmlns:ans2="tcsbank.ru" ans2:e="e">
+          | <ans1:bar xmlns:ans1="example.org" ans1:d="d value" xmlns:ans2="example.com" ans2:e="e">
           |   <foo>
           |     <a>1</a>
           |     <b>b value</b>
@@ -1426,18 +1426,18 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       overrideDefaultAttributeNamespaceWithNamespaceFromAnnotation(fromIterable)
 
     def failWhenElementNameIsIncorrect(toList: String => List[Array[Byte]]): Assertion = {
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tinkoff.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.org")
 
       case class Foo(a: Int, b: String, c: Double)
       case class Bar(@attr d: String, foo: Foo, @attr e: Char)
 
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoder
-      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoder("bar", tcs)
+      implicit val xmlDecoder: XmlDecoder[Bar]     = deriveXmlDecoder("bar", com)
 
       val string1 =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <ans1:wrong xmlns:ans1="tinkoff.ru" d="d value" e="e">
+          | <ans1:wrong xmlns:ans1="example.org" d="d value" e="e">
           |   <foo>
           |     <a>1</a>
           |     <b>b value</b>
@@ -1447,7 +1447,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
         """.stripMargin
       val string2 =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <ans1:bar xmlns:ans1="tcsbank.ru" d="d value" e="e">
+          | <ans1:bar xmlns:ans1="example.com" d="d value" e="e">
           |   <foo>
           |     <a>1</a>
           |     <b>b value</b>
@@ -1461,7 +1461,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       assert(
         decoded1 == Left(DecodingError("Invalid local name. Expected 'bar', but found 'wrong'", List("wrong"), None)) &&
           decoded2 == Left(
-            DecodingError("Invalid namespace. Expected 'tinkoff.ru', but found 'tcsbank.ru'", List("bar"), None),
+            DecodingError("Invalid namespace. Expected 'example.org', but found 'example.com'", List("bar"), None),
           ),
       )
     }
@@ -1472,15 +1472,15 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       failWhenElementNameIsIncorrect(fromIterable)
 
     def decodeSealedTraits(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case class Aquarium(@xmlns(tkf) fish: List[SealedClasses.Pisces])
+      case class Aquarium(@xmlns(org) fish: List[SealedClasses.Pisces])
       implicit val xmlDecoder: XmlDecoder[Aquarium] =
-        deriveXmlDecoderConfigured("aquarium", ElementCodecConfig.default.withNamespaceDefined(tkf))
+        deriveXmlDecoderConfigured("aquarium", ElementCodecConfig.default.withNamespaceDefined(org))
       val string =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <aquarium xmlns:ans1="tinkoff.ru">
+          | <aquarium xmlns:ans1="example.org">
           |   <ans1:fish xmlns:ans2="http://www.w3.org/2001/XMLSchema-instance" ans2:type="ClownFish">
           |     <name>Marlin</name>
           |     <finNumber>3</finNumber>
@@ -1500,16 +1500,16 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
     "decode sealed traits async" in decodeSealedTraits(fromIterable)
 
     def decodeSealedTraitsUsingElementNamesAsDiscriminators(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case class AnimalShelter(@xmlns(tkf) @default animals: List[SealedClasses.Animal])
+      case class AnimalShelter(@xmlns(org) @default animals: List[SealedClasses.Animal])
       implicit val xmlDecoder: XmlDecoder[AnimalShelter] =
-        deriveXmlDecoderConfigured("shelter", ElementCodecConfig.default.withNamespaceDefined(tkf))
+        deriveXmlDecoderConfigured("shelter", ElementCodecConfig.default.withNamespaceDefined(org))
 
       val string =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <shelter xmlns:ans1="tinkoff.ru">
+          | <shelter xmlns:ans1="example.org">
           |   <ans1:cat>
           |     <meow>meow</meow>
           |   </ans1:cat>
@@ -1528,37 +1528,37 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       decodeSealedTraitsUsingElementNamesAsDiscriminators(fromIterable)
 
     def decodeElementsWithScopeNamespaceFromConfig(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
       final case class Qux(g: String, h: Int)
       implicit val quxDecoder: ElementDecoder[Qux] = deriveElementDecoder
 
       final case class Foo(
           d: Int,
-          @xmlns(tcs) e: String,
+          @xmlns(com) e: String,
           f: Double,
           qux: List[Qux],
       )
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoder
 
-      final case class Bar(@xmlns(tcs) a: Int, b: String, c: Double, foo: Foo)
-      val config                               = ElementCodecConfig.default.withScopeDefaultNamespace(tkf)
+      final case class Bar(@xmlns(com) a: Int, b: String, c: Double, foo: Foo)
+      val config                               = ElementCodecConfig.default.withScopeDefaultNamespace(org)
       implicit val barDecoder: XmlDecoder[Bar] = deriveXmlDecoderConfigured("bar", config)
 
       val bar = Bar(123, "b value", 1.234, Foo(321, "e value", 4.321, List(Qux("g value 1", 1), Qux("g value 2", 2))))
       val string1 =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <bar xmlns="tinkoff.ru">
-          |   <ans1:a xmlns:ans1="tcsbank.ru">123</ans1:a>
+          | <bar xmlns="example.org">
+          |   <ans1:a xmlns:ans1="example.com">123</ans1:a>
           |   <b>b value</b>
           |   <c>1.234</c>
           |   <foo>
           |     <d>321</d>
-          |     <ans2:e xmlns:ans2="tcsbank.ru">e value</ans2:e>
+          |     <ans2:e xmlns:ans2="example.com">e value</ans2:e>
           |     <f>4.321</f>
           |     <qux>
           |       <g>g value 1</g>
@@ -1574,7 +1574,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
 
       val string2 =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <ans1:bar xmlns:ans1="tinkoff.ru" xmlns:ans2="tcsbank.ru">
+          | <ans1:bar xmlns:ans1="example.org" xmlns:ans2="example.com">
           |   <ans2:a>123</ans2:a>
           |   <ans1:b>b value</ans1:b>
           |   <ans1:c>1.234</ans1:c>
@@ -1602,37 +1602,37 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
     "decode elements with scope namespace from config async" in decodeElementsWithScopeNamespaceFromConfig(fromIterable)
 
     def decodeElementsWithNestedScopeNamespacesFromConfig(toList: String => List[Array[Byte]]): Assertion = {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
       case object xmp
       implicit val xmlNs: Namespace[xmp.type] = Namespace.mkInstance("example.org")
 
       final case class Foo(
           d: Int,
-          @xmlns(tcs) e: String,
+          @xmlns(com) e: String,
           f: Double,
       )
       val fooConfig                                = ElementCodecConfig.default.withScopeDefaultNamespace(xmp)
       implicit val fooDecoder: ElementDecoder[Foo] = deriveElementDecoderConfigured(fooConfig)
 
-      final case class Bar(@xmlns(tcs) a: Int, b: String, c: Double, foo: Foo)
-      val barConfig                            = ElementCodecConfig.default.withScopeDefaultNamespace(tkf)
+      final case class Bar(@xmlns(com) a: Int, b: String, c: Double, foo: Foo)
+      val barConfig                            = ElementCodecConfig.default.withScopeDefaultNamespace(org)
       implicit val barDecoder: XmlDecoder[Bar] = deriveXmlDecoderConfigured("bar", barConfig)
 
       val bar = Bar(123, "b value", 1.234, Foo(321, "e value", 4.321))
       val string1 =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <bar xmlns="tinkoff.ru">
-          |   <ans1:a xmlns:ans1="tcsbank.ru">123</ans1:a>
+          | <bar xmlns="example.org">
+          |   <ans1:a xmlns:ans1="example.com">123</ans1:a>
           |   <b>b value</b>
           |   <c>1.234</c>
           |   <foo xmlns="example.org">
           |     <d>321</d>
-          |     <ans2:e xmlns:ans2="tcsbank.ru">e value</ans2:e>
+          |     <ans2:e xmlns:ans2="example.com">e value</ans2:e>
           |     <f>4.321</f>
           |   </foo>
           | </bar>
@@ -1640,7 +1640,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
 
       val string2 =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <ans1:bar xmlns:ans1="tinkoff.ru" xmlns:ans2="tcsbank.ru">
+          | <ans1:bar xmlns:ans1="example.org" xmlns:ans2="example.com">
           |   <ans2:a>123</ans2:a>
           |   <ans1:b>b value</ans1:b>
           |   <ans1:c>1.234</ans1:c>

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
@@ -1,14 +1,14 @@
-package ru.tinkoff.phobos
+package phobos
 
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
-import ru.tinkoff.phobos.SealedClasses.{Animal, Cat, Cow, Dog}
-import ru.tinkoff.phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder, XmlEncoder}
-import ru.tinkoff.phobos.testString._
-import ru.tinkoff.phobos.syntax._
-import ru.tinkoff.phobos.configured.naming._
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.derivation.semiauto._
+import phobos.SealedClasses.{Animal, Cat, Cow, Dog}
+import phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder, XmlEncoder}
+import phobos.testString._
+import phobos.syntax._
+import phobos.configured.naming._
+import phobos.configured.ElementCodecConfig
+import phobos.derivation.semiauto._
 
 import scala.annotation.nowarn
 
@@ -585,7 +585,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             | <?xml version='1.0' encoding='UTF-8'?>
             | <quux>
             |   <d>d value</d>
-            |   <baz xmlns:ans1="https://tinkoff.ru" ans1:discriminator="Baz1">
+            |   <baz xmlns:ans1="https://example.org" ans1:discriminator="Baz1">
             |     <a>string</a>
             |   </baz>
             |   <e>k</e>
@@ -596,7 +596,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
               | <?xml version='1.0' encoding='UTF-8'?>
               | <quux>
               |   <d>d value</d>
-              |   <baz xmlns:ans1="https://tinkoff.ru" ans1:discriminator="Baz2">
+              |   <baz xmlns:ans1="https://example.org" ans1:discriminator="Baz2">
               |     <b>1</b>
               |   </baz>
               |   <e>e</e>
@@ -607,7 +607,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
               | <?xml version='1.0' encoding='UTF-8'?>
               | <quux>
               |   <d>another one value</d>
-              |   <baz xmlns:ans1="https://tinkoff.ru" ans1:discriminator="Baz3">
+              |   <baz xmlns:ans1="https://example.org" ans1:discriminator="Baz3">
               |     <c>1.1234</c>
               |   </baz>
               |   <e>v</e>
@@ -746,21 +746,21 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
   "Encoder derivation with namespaces" should {
     "encode simple case classes" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
       case class Foo(
-          @xmlns(tkf) a: Int,
-          @xmlns(tkf) b: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) a: Int,
+          @xmlns(org) b: String,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tkf) d: String,
-          @xmlns(tkf) foo: Foo,
-          @xmlns(tkf) e: Char,
+          @xmlns(org) d: String,
+          @xmlns(org) foo: Foo,
+          @xmlns(org) e: Char,
       )
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoder
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", tkf)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", org)
 
       val bar    = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = XmlEncoder[Bar].encode(bar)
@@ -768,7 +768,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
         string ==
           Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
-            | <ans1:bar xmlns:ans1="tinkoff.ru">
+            | <ans1:bar xmlns:ans1="example.org">
             |   <ans1:d>d value</ans1:d>
             |   <ans1:foo>
             |     <ans1:a>1</ans1:a>
@@ -782,21 +782,21 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "encode attributes" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
       case class Foo(
-          @xmlns(tkf) a: Int,
-          @xmlns(tkf) @attr b: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) a: Int,
+          @xmlns(org) @attr b: String,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tkf) d: String,
-          @xmlns(tkf) foo: Foo,
-          @xmlns(tkf) @attr e: Char,
+          @xmlns(org) d: String,
+          @xmlns(org) foo: Foo,
+          @xmlns(org) @attr e: Char,
       )
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoder
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", tkf)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", org)
 
       val bar    = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = XmlEncoder[Bar].encode(bar)
@@ -804,7 +804,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
         string ==
           Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
-            | <ans1:bar xmlns:ans1="tinkoff.ru" ans1:e="e">
+            | <ans1:bar xmlns:ans1="example.org" ans1:e="e">
             |   <ans1:d>d value</ans1:d>
             |   <ans1:foo ans1:b="b value">
             |     <ans1:a>1</ans1:a>
@@ -816,16 +816,16 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "encode nested namespace" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
       case class Foo(
-          @xmlns(tkf) a: Int,
+          @xmlns(org) a: Int,
           @attr b: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) c: Double,
       )
       case class Bar(
           d: String,
-          @xmlns(tkf) foo: Foo,
+          @xmlns(org) foo: Foo,
           @attr e: Char,
       )
 
@@ -840,7 +840,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             | <?xml version='1.0' encoding='UTF-8'?>
             | <bar e="e">
             |   <d>d value</d>
-            |   <ans1:foo xmlns:ans1="tinkoff.ru" b="b value">
+            |   <ans1:foo xmlns:ans1="example.org" b="b value">
             |     <ans1:a>1</ans1:a>
             |     <ans1:c>3.0</ans1:c>
             |   </ans1:foo>
@@ -850,23 +850,23 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "encode multiple namespaces" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
       case class Foo(
-          @xmlns(tkf) a: Int,
+          @xmlns(org) a: Int,
           @attr b: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tcs) d: String,
-          @xmlns(tkf) foo: Foo,
+          @xmlns(com) d: String,
+          @xmlns(org) foo: Foo,
           @attr e: Char,
       )
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoder
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", tcs)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", com)
 
       val bar    = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = XmlEncoder[Bar].encode(bar)
@@ -874,9 +874,9 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
         string ==
           Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
-            | <ans1:bar xmlns:ans1="tcsbank.ru" e="e">
+            | <ans1:bar xmlns:ans1="example.com" e="e">
             |   <ans1:d>d value</ans1:d>
-            |   <ans2:foo xmlns:ans2="tinkoff.ru" b="b value">
+            |   <ans2:foo xmlns:ans2="example.org" b="b value">
             |     <ans2:a>1</ans2:a>
             |     <ans2:c>3.0</ans2:c>
             |   </ans2:foo>
@@ -887,20 +887,20 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
     "encode CamelCase" in {
       val camelCaseConfig = ElementCodecConfig.default.withFieldNamesTransformed(camelCase)
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
       case class Foo(
-          @xmlns(tkf) someName: Int,
-          @xmlns(tkf) someOtherName: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) someName: Int,
+          @xmlns(org) someOtherName: String,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tkf) someTopName: String,
-          @xmlns(tkf) someFoo: Foo,
+          @xmlns(org) someTopName: String,
+          @xmlns(org) someFoo: Foo,
       )
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoderConfigured(camelCaseConfig)
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("Bar", tkf, camelCaseConfig)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("Bar", org, camelCaseConfig)
 
       val bar    = Bar("d value", Foo(1, "b value", 3.0))
       val string = XmlEncoder[Bar].encode(bar)
@@ -908,7 +908,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
         string ==
           Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
-            | <ans1:Bar xmlns:ans1="tinkoff.ru">
+            | <ans1:Bar xmlns:ans1="example.org">
             |   <ans1:SomeTopName>d value</ans1:SomeTopName>
             |   <ans1:SomeFoo>
             |     <ans1:SomeName>1</ans1:SomeName>
@@ -922,20 +922,20 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
     "encode snake_case" in {
       val snakeCaseConfig = ElementCodecConfig.default.withFieldNamesTransformed(snakeCase)
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
       case class Foo(
-          @xmlns(tkf) someName: Int,
-          @xmlns(tkf) someOtherName: String,
-          @xmlns(tkf) c: Double,
+          @xmlns(org) someName: Int,
+          @xmlns(org) someOtherName: String,
+          @xmlns(org) c: Double,
       )
       case class Bar(
-          @xmlns(tkf) someTopName: String,
-          @xmlns(tkf) someFoo: Foo,
+          @xmlns(org) someTopName: String,
+          @xmlns(org) someFoo: Foo,
       )
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoderConfigured(snakeCaseConfig)
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", tkf, snakeCaseConfig)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", org, snakeCaseConfig)
 
       val bar    = Bar("d value", Foo(1, "b value", 3.0))
       val string = XmlEncoder[Bar].encode(bar)
@@ -943,7 +943,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
         string ==
           Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
-            | <ans1:bar xmlns:ans1="tinkoff.ru">
+            | <ans1:bar xmlns:ans1="example.org">
             |   <ans1:some_top_name>d value</ans1:some_top_name>
             |   <ans1:some_foo>
             |     <ans1:some_name>1</ans1:some_name>
@@ -979,16 +979,16 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "encode with default element namespaces" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      val defaultNamespaceConfig = ElementCodecConfig.default.withElementsDefaultNamespace(tkf)
+      val defaultNamespaceConfig = ElementCodecConfig.default.withElementsDefaultNamespace(org)
 
       case class Foo(a: Int, b: String, c: Double)
       case class Bar(@attr d: String, foo: Foo, e: Char)
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoder
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", tkf, defaultNamespaceConfig)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", org, defaultNamespaceConfig)
 
       val bar    = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = XmlEncoder[Bar].encode(bar)
@@ -996,7 +996,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-          | <ans1:bar xmlns:ans1="tinkoff.ru" d="d value">
+          | <ans1:bar xmlns:ans1="example.org" d="d value">
           |   <ans1:foo>
           |     <a>1</a>
           |     <b>b value</b>
@@ -1009,18 +1009,18 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "override default element namespace with namespace from annotation" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
-      val defaultNamespaceConfig = ElementCodecConfig.default.withElementsDefaultNamespace(tkf)
+      val defaultNamespaceConfig = ElementCodecConfig.default.withElementsDefaultNamespace(org)
       case class Foo(a: Int, b: String, c: Double)
-      case class Bar(@attr d: String, @xmlns(tcs) foo: Foo, e: Char)
+      case class Bar(@attr d: String, @xmlns(com) foo: Foo, e: Char)
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoder
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", tkf, defaultNamespaceConfig)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", org, defaultNamespaceConfig)
 
       val bar    = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = XmlEncoder[Bar].encode(bar)
@@ -1028,8 +1028,8 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-            | <ans1:bar xmlns:ans1="tinkoff.ru" d="d value">
-            |   <ans2:foo xmlns:ans2="tcsbank.ru">
+            | <ans1:bar xmlns:ans1="example.org" d="d value">
+            |   <ans2:foo xmlns:ans2="example.com">
             |     <a>1</a>
             |     <b>b value</b>
             |     <c>3.0</c>
@@ -1041,15 +1041,15 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "encode with default attribute namespaces" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      val defaultNamespaceConfig = ElementCodecConfig.default.withAttributesDefaultNamespace(tkf)
+      val defaultNamespaceConfig = ElementCodecConfig.default.withAttributesDefaultNamespace(org)
       case class Foo(a: Int, b: String, c: Double)
       case class Bar(@attr d: String, foo: Foo, @attr e: Char)
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoder
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", tkf, defaultNamespaceConfig)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", org, defaultNamespaceConfig)
 
       val bar    = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = XmlEncoder[Bar].encode(bar)
@@ -1057,7 +1057,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-            | <ans1:bar xmlns:ans1="tinkoff.ru" ans1:d="d value" ans1:e="e">
+            | <ans1:bar xmlns:ans1="example.org" ans1:d="d value" ans1:e="e">
             |   <foo>
             |     <a>1</a>
             |     <b>b value</b>
@@ -1069,18 +1069,18 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "override default attribute namespace with namespace from annotation" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
-      val defaultNamespaceConfig = ElementCodecConfig.default.withAttributesDefaultNamespace(tkf)
+      val defaultNamespaceConfig = ElementCodecConfig.default.withAttributesDefaultNamespace(org)
       case class Foo(a: Int, b: String, c: Double)
-      case class Bar(@attr d: String, foo: Foo, @attr @xmlns(tcs) e: Char)
+      case class Bar(@attr d: String, foo: Foo, @attr @xmlns(com) e: Char)
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoder
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", tkf, defaultNamespaceConfig)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoderConfigured("bar", org, defaultNamespaceConfig)
 
       val bar    = Bar("d value", Foo(1, "b value", 3.0), 'e')
       val string = XmlEncoder[Bar].encode(bar)
@@ -1088,7 +1088,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-            | <ans1:bar xmlns:ans1="tinkoff.ru" ans1:d="d value" xmlns:ans2="tcsbank.ru" ans2:e="e">
+            | <ans1:bar xmlns:ans1="example.org" ans1:d="d value" xmlns:ans2="example.com" ans2:e="e">
             |   <foo>
             |     <a>1</a>
             |     <b>b value</b>
@@ -1100,18 +1100,18 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "define namespaces from config" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
-      val config = ElementCodecConfig.default.withNamespaceDefined(tkf).withNamespaceDefined(tcs)
+      val config = ElementCodecConfig.default.withNamespaceDefined(org).withNamespaceDefined(com)
 
       final case class Foo(
-          @xmlns(tcs) a: Int,
-          @xmlns(tcs) b: String,
-          @xmlns(tcs) c: Double,
+          @xmlns(com) a: Int,
+          @xmlns(com) b: String,
+          @xmlns(com) c: Double,
       )
 
       implicit val xmlEncoder: XmlEncoder[Foo] = deriveXmlEncoderConfigured("foo", config)
@@ -1122,7 +1122,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-            | <foo xmlns:ans1="tcsbank.ru" xmlns:ans2="tinkoff.ru">
+            | <foo xmlns:ans1="example.com" xmlns:ans2="example.org">
             |   <ans1:a>1</ans1:a>
             |   <ans1:b>b value</ans1:b>
             |   <ans1:c>3.0</ans1:c>
@@ -1132,11 +1132,11 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "define namespaces with not bounded prefixes" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
       val config =
         List
@@ -1150,19 +1150,19 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       )
 
       final case class Bar(
-          @xmlns(tcs) foo: Foo,
+          @xmlns(com) foo: Foo,
       )
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoderConfigured(config)
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", tkf)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", org)
 
       val bar    = Bar(Foo(1, "b value", 3.0))
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-          | <ans1:bar xmlns:ans1="tinkoff.ru">
-          |   <ans2:foo xmlns:ans2="tcsbank.ru" xmlns:ans3="example.com/3" xmlns:ans4="example.com/4" 
+          | <ans1:bar xmlns:ans1="example.org">
+          |   <ans2:foo xmlns:ans2="example.com" xmlns:ans3="example.com/3" xmlns:ans4="example.com/4" 
           |             xmlns:ans5="example.com/5" xmlns:ans6="example.com/6" xmlns:ans7="example.com/7" 
           |             xmlns:ans8="example.com/8" xmlns:ans9="example.com/9" xmlns:ans10="example.com/10">
           |     <a>1</a>
@@ -1175,13 +1175,13 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "not define already defined namespaces" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
-      val config = ElementCodecConfig.default.withNamespaceDefined(tkf).withNamespaceDefined(tcs)
+      val config = ElementCodecConfig.default.withNamespaceDefined(org).withNamespaceDefined(com)
       final case class Foo(
           a: Int,
           b: String,
@@ -1193,15 +1193,15 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       )
 
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoderConfigured(config)
-      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", tkf)
+      implicit val xmlEncoder: XmlEncoder[Bar]     = deriveXmlEncoder("bar", org)
 
       val bar    = Bar(Foo(1, "b value", 3.0))
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-            | <ans1:bar xmlns:ans1="tinkoff.ru">
-            |   <foo xmlns:ans2="tcsbank.ru">
+            | <ans1:bar xmlns:ans1="example.org">
+            |   <foo xmlns:ans2="example.com">
             |     <a>1</a>
             |     <b>b value</b>
             |     <c>3.0</c>
@@ -1212,16 +1212,16 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "encode sealed traits" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case class Aquarium(@xmlns(tkf) fish: List[SealedClasses.Pisces])
+      case class Aquarium(@xmlns(org) fish: List[SealedClasses.Pisces])
       implicit val xmlEncoder: XmlEncoder[Aquarium] =
-        deriveXmlEncoderConfigured("aquarium", ElementCodecConfig.default.withNamespaceDefined(tkf))
+        deriveXmlEncoderConfigured("aquarium", ElementCodecConfig.default.withNamespaceDefined(org))
 
       val string =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <aquarium xmlns:ans1="tinkoff.ru">
+          | <aquarium xmlns:ans1="example.org">
           |   <ans1:fish xmlns:ans2="http://www.w3.org/2001/XMLSchema-instance" ans2:type="ClownFish">
           |     <name>Marlin</name>
           |     <finNumber>3</finNumber>
@@ -1238,16 +1238,16 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "encode sealed traits using element names as discriminators" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case class AnimalShelter(@xmlns(tkf) animals: List[SealedClasses.Animal])
+      case class AnimalShelter(@xmlns(org) animals: List[SealedClasses.Animal])
       implicit val xmlEncoder: XmlEncoder[AnimalShelter] =
-        deriveXmlEncoderConfigured("shelter", ElementCodecConfig.default.withNamespaceDefined(tkf))
+        deriveXmlEncoderConfigured("shelter", ElementCodecConfig.default.withNamespaceDefined(org))
 
       val string =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <shelter xmlns:ans1="tinkoff.ru">
+          | <shelter xmlns:ans1="example.org">
           |   <ans1:cat>
           |     <meow>meow</meow>
           |   </ans1:cat>
@@ -1261,46 +1261,46 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "encode namespaces with preferred prefixes" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru", preferredPrefix = Some("tkf"))
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org", preferredPrefix = Some("org"))
 
-      case object tkf2
-      implicit val tkfNs2: Namespace[tkf2.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org2
+      implicit val orgNs2: Namespace[org2.type] = Namespace.mkInstance("example.org")
 
-      case class Bar(@xmlns(tkf2) c: String, @xmlns(tkf) d: String)
+      case class Bar(@xmlns(org2) c: String, @xmlns(org) d: String)
       implicit val barEncoder: ElementEncoder[Bar] = deriveElementEncoder
-      case class Foo(@xmlns(tkf) a: String, @xmlns(tkf) b: Int, @xmlns(tkf) bar: Bar)
-      implicit val fooEncoder: XmlEncoder[Foo] = deriveXmlEncoder("foo", tkf)
+      case class Foo(@xmlns(org) a: String, @xmlns(org) b: Int, @xmlns(org) bar: Bar)
+      implicit val fooEncoder: XmlEncoder[Foo] = deriveXmlEncoder("foo", org)
 
       val foo = Foo("string", 1, Bar("gnirts", "string"))
       val string =
         """<?xml version='1.0' encoding='UTF-8'?>
-          | <tkf:foo xmlns:tkf="tinkoff.ru">
-          |   <tkf:a>string</tkf:a>
-          |   <tkf:b>1</tkf:b>
-          |   <tkf:bar>
-          |     <tkf:c>gnirts</tkf:c>
-          |     <tkf:d>string</tkf:d>
-          |   </tkf:bar>
-          | </tkf:foo>
+          | <org:foo xmlns:org="example.org">
+          |   <org:a>string</org:a>
+          |   <org:b>1</org:b>
+          |   <org:bar>
+          |     <org:c>gnirts</org:c>
+          |     <org:d>string</org:d>
+          |   </org:bar>
+          | </org:foo>
         """.stripMargin.minimized
 
       XmlEncoder[Foo].encode(foo) shouldBe Right(string)
     }
 
     "declare namespaces with preferred prefixes from config" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru", preferredPrefix = Some("tkf"))
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org", preferredPrefix = Some("org"))
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru", preferredPrefix = Some("tcs"))
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com", preferredPrefix = Some("com"))
 
-      val config = ElementCodecConfig.default.withNamespaceDefined(tkf).withNamespaceDefined(tcs)
+      val config = ElementCodecConfig.default.withNamespaceDefined(org).withNamespaceDefined(com)
 
       final case class Foo(
-          @xmlns(tcs) a: Int,
-          @xmlns(tcs) b: String,
-          @xmlns(tcs) c: Double,
+          @xmlns(com) a: Int,
+          @xmlns(com) b: String,
+          @xmlns(com) c: Double,
       )
 
       implicit val xmlEncoder: XmlEncoder[Foo] = deriveXmlEncoderConfigured("foo", config)
@@ -1311,35 +1311,35 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-            | <foo xmlns:tcs="tcsbank.ru" xmlns:tkf="tinkoff.ru">
-            |   <tcs:a>1</tcs:a>
-            |   <tcs:b>b value</tcs:b>
-            |   <tcs:c>3.0</tcs:c>
+            | <foo xmlns:com="example.com" xmlns:org="example.org">
+            |   <com:a>1</com:a>
+            |   <com:b>b value</com:b>
+            |   <com:c>3.0</com:c>
             | </foo>
      """.stripMargin.minimized),
       )
     }
 
     "declare scope namespace from config" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
       final case class Qux(g: String, h: Int)
       implicit val quxEncoder: ElementEncoder[Qux] = deriveElementEncoder
 
       final case class Foo(
           d: Int,
-          @xmlns(tcs) e: String,
+          @xmlns(com) e: String,
           f: Double,
           qux: List[Qux],
       )
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoder
 
-      final case class Bar(@xmlns(tcs) a: Int, b: String, c: Double, foo: Foo)
-      val config                               = ElementCodecConfig.default.withScopeDefaultNamespace(tkf)
+      final case class Bar(@xmlns(com) a: Int, b: String, c: Double, foo: Foo)
+      val config                               = ElementCodecConfig.default.withScopeDefaultNamespace(org)
       implicit val barEncoder: XmlEncoder[Bar] = deriveXmlEncoderConfigured("bar", config)
 
       val bar    = Bar(123, "b value", 1.234, Foo(321, "e value", 4.321, List(Qux("g value 1", 1), Qux("g value 2", 2))))
@@ -1347,13 +1347,13 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-          | <bar xmlns="tinkoff.ru">
-          |   <ans1:a xmlns:ans1="tcsbank.ru">123</ans1:a>
+          | <bar xmlns="example.org">
+          |   <ans1:a xmlns:ans1="example.com">123</ans1:a>
           |   <b>b value</b>
           |   <c>1.234</c>
           |   <foo>
           |     <d>321</d>
-          |     <ans2:e xmlns:ans2="tcsbank.ru">e value</ans2:e>
+          |     <ans2:e xmlns:ans2="example.com">e value</ans2:e>
           |     <f>4.321</f>
           |     <qux>
           |       <g>g value 1</g>
@@ -1370,25 +1370,25 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
     }
 
     "declare nested scope namespaces from config" in {
-      case object tkf
-      implicit val tkfNs: Namespace[tkf.type] = Namespace.mkInstance("tinkoff.ru")
+      case object org
+      implicit val orgNs: Namespace[org.type] = Namespace.mkInstance("example.org")
 
-      case object tcs
-      implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
+      case object com
+      implicit val comNs: Namespace[com.type] = Namespace.mkInstance("example.com")
 
       case object xmp
       implicit val xmlNs: Namespace[xmp.type] = Namespace.mkInstance("example.org")
 
       final case class Foo(
           d: Int,
-          @xmlns(tcs) e: String,
+          @xmlns(com) e: String,
           f: Double,
       )
       val fooConfig                                = ElementCodecConfig.default.withScopeDefaultNamespace(xmp)
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoderConfigured(fooConfig)
 
-      final case class Bar(@xmlns(tcs) a: Int, b: String, c: Double, foo: Foo)
-      val barConfig                            = ElementCodecConfig.default.withScopeDefaultNamespace(tkf)
+      final case class Bar(@xmlns(com) a: Int, b: String, c: Double, foo: Foo)
+      val barConfig                            = ElementCodecConfig.default.withScopeDefaultNamespace(org)
       implicit val barEncoder: XmlEncoder[Bar] = deriveXmlEncoderConfigured("bar", barConfig)
 
       val bar    = Bar(123, "b value", 1.234, Foo(321, "e value", 4.321))
@@ -1396,13 +1396,13 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       assert(
         string ==
           Right("""<?xml version='1.0' encoding='UTF-8'?>
-            | <bar xmlns="tinkoff.ru">
-            |   <ans1:a xmlns:ans1="tcsbank.ru">123</ans1:a>
+            | <bar xmlns="example.org">
+            |   <ans1:a xmlns:ans1="example.com">123</ans1:a>
             |   <b>b value</b>
             |   <c>1.234</c>
             |   <foo xmlns="example.org">
             |     <d>321</d>
-            |     <ans2:e xmlns:ans2="tcsbank.ru">e value</ans2:e>
+            |     <ans2:e xmlns:ans2="example.com">e value</ans2:e>
             |     <f>4.321</f>
             |   </foo>
             | </bar>

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/SealedClasses.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/SealedClasses.scala
@@ -1,11 +1,11 @@
-package ru.tinkoff.phobos
+package phobos
 
-import ru.tinkoff.phobos.configured.ElementCodecConfig
-import ru.tinkoff.phobos.configured.naming._
-import ru.tinkoff.phobos.decoding.ElementDecoder
-import ru.tinkoff.phobos.derivation.semiauto._
-import ru.tinkoff.phobos.encoding.ElementEncoder
-import ru.tinkoff.phobos.syntax.discriminator
+import phobos.configured.ElementCodecConfig
+import phobos.configured.naming._
+import phobos.decoding.ElementDecoder
+import phobos.derivation.semiauto._
+import phobos.encoding.ElementEncoder
+import phobos.syntax.discriminator
 
 object SealedClasses {
   sealed trait Foo
@@ -52,7 +52,7 @@ object SealedClasses {
   case class Baz3(c: Double) extends Baz
 
   object Baz {
-    val config                                     = ElementCodecConfig.default.withDiscriminator("discriminator", Some("https://tinkoff.ru"))
+    val config                                     = ElementCodecConfig.default.withDiscriminator("discriminator", Some("https://example.org"))
     implicit val baz1Encoder: ElementEncoder[Baz1] = deriveElementEncoder
     implicit val baz2Encoder: ElementEncoder[Baz2] = deriveElementEncoder
     implicit val baz3Encoder: ElementEncoder[Baz3] = deriveElementEncoder

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/XmlEncoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/XmlEncoderTest.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos
+package phobos
 
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
-import ru.tinkoff.phobos.derivation.semiauto.deriveXmlEncoder
-import ru.tinkoff.phobos.encoding.XmlEncoder
+import phobos.derivation.semiauto.deriveXmlEncoder
+import phobos.encoding.XmlEncoder
 
 class XmlEncoderTest extends AnyWordSpec with Matchers {
   "XmlEncoder with config" should {

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/decoding/AttributeDecoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/decoding/AttributeDecoderTest.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.derivation.semiauto._
-import ru.tinkoff.phobos.syntax.attr
+import phobos.derivation.semiauto._
+import phobos.syntax.attr
 
 import java.time.OffsetDateTime
 

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/decoding/ElementDecoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/decoding/ElementDecoderTest.scala
@@ -1,8 +1,8 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.derivation.semiauto.deriveXmlDecoder
+import phobos.derivation.semiauto.deriveXmlDecoder
 
 import java.time.OffsetDateTime
 

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/decoding/TextDecoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/decoding/TextDecoderTest.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.decoding
+package phobos.decoding
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.derivation.semiauto.deriveXmlDecoder
-import ru.tinkoff.phobos.syntax.text
+import phobos.derivation.semiauto.deriveXmlDecoder
+import phobos.syntax.text
 
 import java.time.OffsetDateTime
 

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/encoding/AttributeEncoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/encoding/AttributeEncoderTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 import com.fasterxml.aalto.out.WriterConfig
 import org.scalatest.matchers.should.Matchers

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/encoding/ElementEncoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/encoding/ElementEncoderTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 import com.fasterxml.aalto.out.WriterConfig
 import org.scalatest.matchers.should.Matchers

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/encoding/EncoderTestBase.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/encoding/EncoderTestBase.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 import com.fasterxml.aalto.out._
 

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/encoding/TextEncoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/encoding/TextEncoderTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.encoding
+package phobos.encoding
 
 import com.fasterxml.aalto.out.WriterConfig
 import org.scalatest.matchers.should.Matchers

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/testString.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/testString.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos
+package phobos
 
 object testString {
   implicit class StringOps(str: String) {

--- a/modules/derevo/src/main/scala/ru/tinkoff/phobos/derevo/elementDecoder.scala
+++ b/modules/derevo/src/main/scala/ru/tinkoff/phobos/derevo/elementDecoder.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.derevo
+package phobos.derevo
 
 import derevo.{Derevo, Derivation, delegating}
-import ru.tinkoff.phobos.decoding.ElementDecoder
+import phobos.decoding.ElementDecoder
 
-@delegating("ru.tinkoff.phobos.derivation.semiauto.deriveElementDecoder")
+@delegating("phobos.derivation.semiauto.deriveElementDecoder")
 object elementDecoder extends Derivation[ElementDecoder] {
   implicit def instance[T]: ElementDecoder[T] = macro Derevo.delegate[ElementDecoder, T]
 }

--- a/modules/derevo/src/main/scala/ru/tinkoff/phobos/derevo/elementEncoder.scala
+++ b/modules/derevo/src/main/scala/ru/tinkoff/phobos/derevo/elementEncoder.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.derevo
+package phobos.derevo
 
 import derevo.{Derevo, Derivation, delegating}
-import ru.tinkoff.phobos.encoding.ElementEncoder
+import phobos.encoding.ElementEncoder
 
-@delegating("ru.tinkoff.phobos.derivation.semiauto.deriveElementEncoder")
+@delegating("phobos.derivation.semiauto.deriveElementEncoder")
 object elementEncoder extends Derivation[ElementEncoder] {
   implicit def instance[T]: ElementEncoder[T] = macro Derevo.delegate[ElementEncoder, T]
 }

--- a/modules/derevo/src/main/scala/ru/tinkoff/phobos/derevo/xmlDecoder.scala
+++ b/modules/derevo/src/main/scala/ru/tinkoff/phobos/derevo/xmlDecoder.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.derevo
+package phobos.derevo
 
 import derevo.{Derevo, Derivation, delegating}
-import ru.tinkoff.phobos.decoding.XmlDecoder
+import phobos.decoding.XmlDecoder
 
-@delegating("ru.tinkoff.phobos.derivation.semiauto.deriveXmlDecoder")
+@delegating("phobos.derivation.semiauto.deriveXmlDecoder")
 object xmlDecoder extends Derivation[XmlDecoder] {
 
   def apply[A](arg: String): XmlDecoder[A] = macro Derevo.delegateParam[XmlDecoder, A, String]

--- a/modules/derevo/src/main/scala/ru/tinkoff/phobos/derevo/xmlEncoder.scala
+++ b/modules/derevo/src/main/scala/ru/tinkoff/phobos/derevo/xmlEncoder.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.derevo
+package phobos.derevo
 
 import derevo.{Derevo, Derivation, delegating}
-import ru.tinkoff.phobos.encoding.XmlEncoder
+import phobos.encoding.XmlEncoder
 
-@delegating("ru.tinkoff.phobos.derivation.semiauto.deriveXmlEncoder")
+@delegating("phobos.derivation.semiauto.deriveXmlEncoder")
 object xmlEncoder extends Derivation[XmlEncoder] {
 
   def apply[A](arg: String): XmlEncoder[A] = macro Derevo.delegateParam[XmlEncoder, A, String]

--- a/modules/derevo/src/test/scala/ru/tinkoff/phobos/derevo/DerevoTest.scala
+++ b/modules/derevo/src/test/scala/ru/tinkoff/phobos/derevo/DerevoTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.derevo
+package phobos.derevo
 
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
@@ -8,8 +8,8 @@ class DerevoTest extends AnyWordSpec with Matchers {
     "derive xml encoder without namespace" in {
       """
         | import derevo.derive
-        | import ru.tinkoff.phobos.derevo.xmlEncoder
-        | import ru.tinkoff.phobos.encoding.XmlEncoder
+        | import phobos.derevo.xmlEncoder
+        | import phobos.encoding.XmlEncoder
         | @derive(xmlEncoder("foo"))
         | case class Foo(int: Int, string: String, double: Double)
         | implicitly[XmlEncoder[Foo]]
@@ -19,12 +19,12 @@ class DerevoTest extends AnyWordSpec with Matchers {
     "derive xml encoder with namespace" in {
       """
         | import derevo.derive
-        | import ru.tinkoff.phobos.annotations.XmlnsDef
-        | import ru.tinkoff.phobos.derevo.xmlEncoder
-        | import ru.tinkoff.phobos.encoding.XmlEncoder
-        | @XmlnsDef("tinkoff.ru")
-        | case object tkf
-        | @derive(xmlEncoder("foo", tkf))
+        | import phobos.annotations.XmlnsDef
+        | import phobos.derevo.xmlEncoder
+        | import phobos.encoding.XmlEncoder
+        | @XmlnsDef("example.org")
+        | case object org
+        | @derive(xmlEncoder("foo", org))
         | case class Foo(int: Int, string: String, double: Double)
         | implicitly[XmlEncoder[Foo]]
       """.stripMargin should compile
@@ -33,8 +33,8 @@ class DerevoTest extends AnyWordSpec with Matchers {
     "derive xml decoder without namespace" in {
       """
         | import derevo.derive
-        | import ru.tinkoff.phobos.derevo.xmlDecoder
-        | import ru.tinkoff.phobos.decoding.XmlDecoder
+        | import phobos.derevo.xmlDecoder
+        | import phobos.decoding.XmlDecoder
         | @derive(xmlDecoder("foo"))
         | case class Foo(int: Int, string: String, double: Double)
         | implicitly[XmlDecoder[Foo]]
@@ -44,12 +44,12 @@ class DerevoTest extends AnyWordSpec with Matchers {
     "derive xml decoder with namespace" in {
       """
         | import derevo.derive
-        | import ru.tinkoff.phobos.annotations.XmlnsDef
-        | import ru.tinkoff.phobos.derevo.xmlDecoder
-        | import ru.tinkoff.phobos.decoding.XmlDecoder
-        | @XmlnsDef("tinkoff.ru")
-        | case object tkf
-        | @derive(xmlDecoder("foo", tkf))
+        | import phobos.annotations.XmlnsDef
+        | import phobos.derevo.xmlDecoder
+        | import phobos.decoding.XmlDecoder
+        | @XmlnsDef("example.org")
+        | case object org
+        | @derive(xmlDecoder("foo", org))
         | case class Foo(int: Int, string: String, double: Double)
         | implicitly[XmlDecoder[Foo]]
       """.stripMargin should compile

--- a/modules/enumeratum/src/main/scala/ru/tinkoff/phobos/enumeratum/XmlEnum.scala
+++ b/modules/enumeratum/src/main/scala/ru/tinkoff/phobos/enumeratum/XmlEnum.scala
@@ -1,8 +1,8 @@
-package ru.tinkoff.phobos.enumeratum
+package phobos.enumeratum
 
 import enumeratum.{Enum, EnumEntry}
-import ru.tinkoff.phobos.decoding.{AttributeDecoder, DecodingError, ElementDecoder, TextDecoder}
-import ru.tinkoff.phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder}
+import phobos.decoding.{AttributeDecoder, DecodingError, ElementDecoder, TextDecoder}
+import phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder}
 
 trait XmlEnum[A <: EnumEntry] { this: Enum[A] =>
   implicit val enumElementEncoder: ElementEncoder[A]     = ElementEncoder.stringEncoder.contramap(a => a.entryName)

--- a/modules/enumeratum/src/test/scala/ru/tinkoff/phobos/enumeratum/EnumeratumTest.scala
+++ b/modules/enumeratum/src/test/scala/ru/tinkoff/phobos/enumeratum/EnumeratumTest.scala
@@ -1,14 +1,14 @@
-package ru.tinkoff.phobos.enumeratum
+package phobos.enumeratum
 
 import enumeratum._
 import org.scalatest.Assertion
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
-import ru.tinkoff.phobos.annotations.XmlCodec
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.encoding.XmlEncoder
-import ru.tinkoff.phobos.syntax._
-import ru.tinkoff.phobos.testString._
+import phobos.annotations.XmlCodec
+import phobos.decoding.XmlDecoder
+import phobos.encoding.XmlEncoder
+import phobos.syntax._
+import phobos.testString._
 
 class EnumeratumTest extends AnyWordSpec with Matchers {
   "Enum codecs" should {

--- a/modules/fs2-ce2/src/main/scala/ru/tinkoff/phobos/fs2/Fs2Ops.scala
+++ b/modules/fs2-ce2/src/main/scala/ru/tinkoff/phobos/fs2/Fs2Ops.scala
@@ -1,10 +1,10 @@
-package ru.tinkoff.phobos.fs2
+package phobos.fs2
 
 import cats.MonadError
 import cats.syntax.flatMap._
 import fs2.Stream
 import javax.xml.stream.XMLStreamConstants
-import ru.tinkoff.phobos.decoding.{Cursor, ElementDecoder, XmlDecoder, XmlStreamReader}
+import phobos.decoding.{Cursor, ElementDecoder, XmlDecoder, XmlStreamReader}
 
 trait Fs2Ops {
   implicit def decoderOps[A](xmlDecoder: XmlDecoder[A]): DecoderOps[A] = new DecoderOps[A](xmlDecoder)

--- a/modules/fs2-ce2/src/main/scala/ru/tinkoff/phobos/fs2/Parse.scala
+++ b/modules/fs2-ce2/src/main/scala/ru/tinkoff/phobos/fs2/Parse.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.fs2
+package phobos.fs2
 
 import cats.data.NonEmptyList
 import cats.effect.Sync
 import fs2._
-import ru.tinkoff.phobos.decoding._
+import phobos.decoding._
 import com.fasterxml.aalto.AsyncXMLStreamReader.EVENT_INCOMPLETE
 import javax.xml.stream.XMLStreamConstants._
 import scala.annotation.tailrec

--- a/modules/fs2-ce2/src/main/scala/ru/tinkoff/phobos/fs2/package.scala
+++ b/modules/fs2-ce2/src/main/scala/ru/tinkoff/phobos/fs2/package.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos
+package phobos
 
 package object fs2 extends Fs2Ops

--- a/modules/fs2-ce2/src/test/scala/ru/tinkoff/phobos/test/Fs2Test.scala
+++ b/modules/fs2-ce2/src/test/scala/ru/tinkoff/phobos/test/Fs2Test.scala
@@ -1,14 +1,14 @@
-package ru.tinkoff.phobos.test
+package phobos.test
 
 import org.scalatest.wordspec.AsyncWordSpec
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.syntax.text
-import ru.tinkoff.phobos.fs2._
+import phobos.decoding.XmlDecoder
+import phobos.syntax.text
+import phobos.fs2._
 import fs2.Stream
 import cats.effect.IO
-import ru.tinkoff.phobos.decoding.ElementDecoder
-import ru.tinkoff.phobos.derivation.semiauto.deriveElementDecoder
-import ru.tinkoff.phobos.derivation.semiauto.deriveXmlDecoder
+import phobos.decoding.ElementDecoder
+import phobos.derivation.semiauto.deriveElementDecoder
+import phobos.derivation.semiauto.deriveXmlDecoder
 
 import scala.annotation.nowarn
 

--- a/modules/fs2-ce2/src/test/scala/ru/tinkoff/phobos/test/ParseTest.scala
+++ b/modules/fs2-ce2/src/test/scala/ru/tinkoff/phobos/test/ParseTest.scala
@@ -1,14 +1,14 @@
-package ru.tinkoff.phobos.test
+package phobos.test
 
 import org.scalatest.wordspec.AsyncWordSpec
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.syntax.text
-import ru.tinkoff.phobos.fs2._
+import phobos.decoding.XmlDecoder
+import phobos.syntax.text
+import phobos.fs2._
 import fs2.Stream
 import cats.effect.IO
 import org.scalatest.Inspectors
-import ru.tinkoff.phobos.decoding.DecodingError
-import ru.tinkoff.phobos.derivation.semiauto.deriveXmlDecoder
+import phobos.decoding.DecodingError
+import phobos.derivation.semiauto.deriveXmlDecoder
 
 class ParseTest extends AsyncWordSpec with Inspectors {
 

--- a/modules/fs2/src/main/scala/ru/tinkoff/phobos/fs2/Fs2Ops.scala
+++ b/modules/fs2/src/main/scala/ru/tinkoff/phobos/fs2/Fs2Ops.scala
@@ -1,10 +1,10 @@
-package ru.tinkoff.phobos.fs2
+package phobos.fs2
 
 import cats.MonadError
 import cats.syntax.flatMap._
 import fs2.{Stream, Compiler}
 import javax.xml.stream.XMLStreamConstants
-import ru.tinkoff.phobos.decoding.{Cursor, ElementDecoder, XmlDecoder, XmlStreamReader}
+import phobos.decoding.{Cursor, ElementDecoder, XmlDecoder, XmlStreamReader}
 
 trait Fs2Ops {
   implicit def decoderOps[A](xmlDecoder: XmlDecoder[A]): DecoderOps[A] = new DecoderOps[A](xmlDecoder)

--- a/modules/fs2/src/main/scala/ru/tinkoff/phobos/fs2/Parse.scala
+++ b/modules/fs2/src/main/scala/ru/tinkoff/phobos/fs2/Parse.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.fs2
+package phobos.fs2
 
 import cats.data.NonEmptyList
 import cats.effect.Sync
 import fs2._
-import ru.tinkoff.phobos.decoding._
+import phobos.decoding._
 import com.fasterxml.aalto.AsyncXMLStreamReader.EVENT_INCOMPLETE
 import javax.xml.stream.XMLStreamConstants._
 import scala.annotation.tailrec

--- a/modules/fs2/src/main/scala/ru/tinkoff/phobos/fs2/package.scala
+++ b/modules/fs2/src/main/scala/ru/tinkoff/phobos/fs2/package.scala
@@ -1,3 +1,3 @@
-package ru.tinkoff.phobos
+package phobos
 
 package object fs2 extends Fs2Ops

--- a/modules/fs2/src/test/scala/ru/tinkoff/phobos/test/Fs2Test.scala
+++ b/modules/fs2/src/test/scala/ru/tinkoff/phobos/test/Fs2Test.scala
@@ -1,15 +1,15 @@
-package ru.tinkoff.phobos.test
+package phobos.test
 
 import org.scalatest.wordspec.AsyncWordSpec
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.syntax.text
-import ru.tinkoff.phobos.fs2._
+import phobos.decoding.XmlDecoder
+import phobos.syntax.text
+import phobos.fs2._
 import fs2.Stream
 import cats.effect.IO
 import cats.effect.unsafe.{IORuntimeConfig, Scheduler, IORuntime}
-import ru.tinkoff.phobos.decoding.ElementDecoder
-import ru.tinkoff.phobos.derivation.semiauto.deriveElementDecoder
-import ru.tinkoff.phobos.derivation.semiauto.deriveXmlDecoder
+import phobos.decoding.ElementDecoder
+import phobos.derivation.semiauto.deriveElementDecoder
+import phobos.derivation.semiauto.deriveXmlDecoder
 
 import scala.annotation.nowarn
 

--- a/modules/fs2/src/test/scala/ru/tinkoff/phobos/test/ParseTest.scala
+++ b/modules/fs2/src/test/scala/ru/tinkoff/phobos/test/ParseTest.scala
@@ -1,15 +1,15 @@
-package ru.tinkoff.phobos.test
+package phobos.test
 
 import org.scalatest.wordspec.AsyncWordSpec
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.syntax.text
-import ru.tinkoff.phobos.fs2._
+import phobos.decoding.XmlDecoder
+import phobos.syntax.text
+import phobos.fs2._
 import fs2.Stream
 import cats.effect.IO
 import cats.effect.unsafe.{IORuntimeConfig, Scheduler, IORuntime}
 import org.scalatest.Inspectors
-import ru.tinkoff.phobos.decoding.DecodingError
-import ru.tinkoff.phobos.derivation.semiauto.deriveXmlDecoder
+import phobos.decoding.DecodingError
+import phobos.derivation.semiauto.deriveXmlDecoder
 
 class ParseTest extends AsyncWordSpec with Inspectors {
   val (scheduler, shutdown) = Scheduler.createDefaultScheduler()

--- a/modules/monix/src/main/scala/ru/tinkoff/phobos/monix.scala
+++ b/modules/monix/src/main/scala/ru/tinkoff/phobos/monix.scala
@@ -1,5 +1,5 @@
-package ru.tinkoff.phobos
+package phobos
 
-import ru.tinkoff.phobos.ops.MonixOps
+import phobos.ops.MonixOps
 
 object monix extends MonixOps

--- a/modules/monix/src/main/scala/ru/tinkoff/phobos/ops/MonixOps.scala
+++ b/modules/monix/src/main/scala/ru/tinkoff/phobos/ops/MonixOps.scala
@@ -1,9 +1,9 @@
-package ru.tinkoff.phobos.ops
+package phobos.ops
 
 import javax.xml.stream.XMLStreamConstants
 import monix.eval.Task
 import monix.reactive.Observable
-import ru.tinkoff.phobos.decoding.{Cursor, ElementDecoder, XmlDecoder, XmlStreamReader}
+import phobos.decoding.{Cursor, ElementDecoder, XmlDecoder, XmlStreamReader}
 
 private[phobos] trait MonixOps {
   implicit def DecoderOps[A](xmlDecoder: XmlDecoder[A]): DecoderOps[A] = new DecoderOps[A](xmlDecoder)

--- a/modules/monix/src/test/scala/ru/tinkoff/phobos/test/MonixTest.scala
+++ b/modules/monix/src/test/scala/ru/tinkoff/phobos/test/MonixTest.scala
@@ -1,14 +1,14 @@
-package ru.tinkoff.phobos.test
+package phobos.test
 
 import java.util.concurrent.Executors
 import monix.execution.Scheduler
 import monix.reactive.Observable
 import org.scalatest.wordspec.AsyncWordSpec
-import ru.tinkoff.phobos.decoding.ElementDecoder
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.derivation.semiauto._
-import ru.tinkoff.phobos.syntax.text
-import ru.tinkoff.phobos.monix._
+import phobos.decoding.ElementDecoder
+import phobos.decoding.XmlDecoder
+import phobos.derivation.semiauto._
+import phobos.syntax.text
+import phobos.monix._
 
 import scala.annotation.nowarn
 

--- a/modules/refined/src/main/scala/ru/tinkoff/phobos/refined/decoding/DecodingInstances.scala
+++ b/modules/refined/src/main/scala/ru/tinkoff/phobos/refined/decoding/DecodingInstances.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.refined.decoding
+package phobos.refined.decoding
 
 import eu.timepit.refined.api.{RefType, Validate}
-import ru.tinkoff.phobos.decoding._
+import phobos.decoding._
 import scala.reflect.runtime.universe.TypeTag
 
 trait DecodingInstances {

--- a/modules/refined/src/main/scala/ru/tinkoff/phobos/refined/encoding/EncodingInstances.scala
+++ b/modules/refined/src/main/scala/ru/tinkoff/phobos/refined/encoding/EncodingInstances.scala
@@ -1,7 +1,7 @@
-package ru.tinkoff.phobos.refined.encoding
+package phobos.refined.encoding
 
 import eu.timepit.refined.api.RefType
-import ru.tinkoff.phobos.encoding._
+import phobos.encoding._
 
 trait EncodingInstances {
 

--- a/modules/refined/src/main/scala/ru/tinkoff/phobos/refined/package.scala
+++ b/modules/refined/src/main/scala/ru/tinkoff/phobos/refined/package.scala
@@ -1,6 +1,6 @@
-package ru.tinkoff.phobos
+package phobos
 
-import ru.tinkoff.phobos.refined.decoding.DecodingInstances
-import ru.tinkoff.phobos.refined.encoding.EncodingInstances
+import phobos.refined.decoding.DecodingInstances
+import phobos.refined.encoding.EncodingInstances
 
 package object refined extends DecodingInstances with EncodingInstances

--- a/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedDecodersTest.scala
+++ b/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedDecodersTest.scala
@@ -1,4 +1,4 @@
-package ru.tinkoff.phobos.refined
+package phobos.refined
 
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.refineMV
@@ -6,10 +6,10 @@ import eu.timepit.refined.string.MatchesRegex
 import eu.timepit.refined.types.numeric.NonNegLong
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.annotations.{XmlCodec, ElementCodec}
-import ru.tinkoff.phobos.decoding.XmlDecoder
-import ru.tinkoff.phobos.syntax.{text, attr}
-import ru.tinkoff.phobos.testString._
+import phobos.annotations.{XmlCodec, ElementCodec}
+import phobos.decoding.XmlDecoder
+import phobos.syntax.{text, attr}
+import phobos.testString._
 import shapeless.{Witness => W}
 
 import scala.annotation.nowarn

--- a/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedEncodersTest.scala
+++ b/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedEncodersTest.scala
@@ -1,16 +1,16 @@
-package ru.tinkoff.phobos.refined
+package phobos.refined
 
 import eu.timepit.refined.api.Refined
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import ru.tinkoff.phobos.annotations.{ElementCodec, XmlCodec}
+import phobos.annotations.{ElementCodec, XmlCodec}
 import eu.timepit.refined.refineMV
 import eu.timepit.refined.string.MatchesRegex
 import eu.timepit.refined.types.numeric.NonNegLong
-import ru.tinkoff.phobos.encoding.XmlEncoder
-import ru.tinkoff.phobos.syntax.{attr, text}
+import phobos.encoding.XmlEncoder
+import phobos.syntax.{attr, text}
 import shapeless.{Witness => W}
-import ru.tinkoff.phobos.testString._
+import phobos.testString._
 
 class RefinedEncodersTest extends AnyWordSpec with Matchers {
   type NumericAtLeastTwo = MatchesRegex[W.`"[0-9]{2,}"`.T]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 logLevel := Level.Warn
 
+//addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"      % "3.10.0-31-9c0bbe91")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"      % "3.9.21")
 addSbtPlugin("com.github.sbt" % "sbt-pgp"           % "2.2.1")
 addSbtPlugin("com.github.sbt" % "sbt-git"           % "2.0.1")

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,8 +1,9 @@
 import Publish._
+//import xerial.sbt.Sonatype.sonatypeCentralHost
 
 publishVersion := "0.21.0"
 
-ThisBuild / organization := "ru.tinkoff"
+ThisBuild / organization := "dev.valentiay"
 ThisBuild / version := {
   val branch = git.gitCurrentBranch.value
   if (branch == "master") publishVersion.value
@@ -10,7 +11,7 @@ ThisBuild / version := {
 }
 
 ThisBuild / publishMavenStyle := true
-
+//ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 ThisBuild / publishTo :=
   (if (!isSnapshot.value) {
      sonatypePublishToBundle.value
@@ -20,8 +21,8 @@ ThisBuild / publishTo :=
 
 ThisBuild / scmInfo := Some(
   ScmInfo(
-    url("https://github.com/Tinkoff/phobos"),
-    "git@github.com:Tinkoff/phobos",
+    url("https://github.com/valentiay/phobos"),
+    "git@github.com:valentiay/phobos",
   ),
 )
 
@@ -29,14 +30,14 @@ ThisBuild / developers := List(
   Developer(
     id = "valentiay",
     name = "Alexander Valentinov",
-    email = "a.valentinov@tinkoff.ru",
+    email = "valentiay@yandex.ru",
     url = url("https://github.com/valentiay"),
   ),
 )
 
 ThisBuild / description := "Fast xml data binding library"
 ThisBuild / licenses    := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
-ThisBuild / homepage    := Some(url("https://github.com/Tinkoff/phobos"))
+ThisBuild / homepage    := Some(url("https://github.com/valentiay/phobos"))
 
 // Remove all additional repository other than Maven Central from POM
 ThisBuild / pomIncludeRepository := { _ => false }


### PR DESCRIPTION
This PR prepares Phobos to be published in dev.valentiay sonatype org, replacing ru.tinkoff.

It also drops organization prefix in package structure: `import ru.tinkoff.phobos.*` becomes `import phobos.*`
