### PR TITLE
Don't fail on comments before the first element

### DIFF
--- a/modules/akka-stream/src/main/scala/phobos/akka_stream/AkkaStreamOps.scala
+++ b/modules/akka-stream/src/main/scala/phobos/akka_stream/AkkaStreamOps.scala
@@ -23,9 +23,7 @@ private[phobos] trait AkkaStreamOps {
         import state.{cursor, elementDecoder, xmlStreamReader}
         xmlStreamReader.getInputFeeder.feedInput(bytes, 0, bytes.length)
         cursor.next()
-        while (
-          cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT
-        ) {
+        while (XmlDecoder.isIgnorableEvent(cursor.getEventType)) {
           cursor.next()
         }
 

--- a/modules/cats/src/main/scala/phobos/catsInstances.scala
+++ b/modules/cats/src/main/scala/phobos/catsInstances.scala
@@ -93,9 +93,7 @@ object catsInstances {
       val a = Foldable[F].foldLeft(f, xmlDecoder.elementdecoder) { (decoder: ElementDecoder[A], bytes: Array[Byte]) =>
         sr.getInputFeeder.feedInput(bytes, 0, bytes.length)
         cursor.next()
-        while (
-          cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT
-        ) {
+        while (XmlDecoder.isIgnorableEvent(cursor.getEventType)) {
           cursor.next()
         }
 

--- a/modules/core/src/main/scala-2.12/phobos/decoding/XmlDecoderIterable.scala
+++ b/modules/core/src/main/scala-2.12/phobos/decoding/XmlDecoderIterable.scala
@@ -16,7 +16,7 @@ trait XmlDecoderIterable[A] { xmlDecoder: XmlDecoder[A] =>
       sr.getInputFeeder.feedInput(bytes, 0, bytes.length)
       do {
         cursor.next()
-      } while (cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT)
+      } while (XmlDecoder.isIgnorableEvent(cursor.getEventType))
 
       if (decoder.result(cursor.history).isRight) {
         decoder

--- a/modules/core/src/main/scala-2.13/phobos/decoding/XmlDecoderIterable.scala
+++ b/modules/core/src/main/scala-2.13/phobos/decoding/XmlDecoderIterable.scala
@@ -16,7 +16,7 @@ trait XmlDecoderIterable[A] { xmlDecoder: XmlDecoder[A] =>
       sr.getInputFeeder.feedInput(bytes, 0, bytes.length)
       do {
         cursor.next()
-      } while (cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT)
+      } while (XmlDecoder.isIgnorableEvent(cursor.getEventType))
 
       if (decoder.result(cursor.history).isRight) {
         decoder

--- a/modules/core/src/main/scala-3/phobos/decoding/XmlDecoderIterable.scala
+++ b/modules/core/src/main/scala-3/phobos/decoding/XmlDecoderIterable.scala
@@ -16,7 +16,7 @@ trait XmlDecoderIterable[A] { xmlDecoder: XmlDecoder[A] =>
       sr.getInputFeeder.feedInput(bytes, 0, bytes.length)
       while {
         cursor.next()
-        cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT
+        XmlDecoder.isIgnorableEvent(cursor.getEventType)
       } do ()
 
       if (decoder.result(cursor.history).isRight) {

--- a/modules/core/src/main/scala/phobos/decoding/XmlDecoder.scala
+++ b/modules/core/src/main/scala/phobos/decoding/XmlDecoder.scala
@@ -35,9 +35,7 @@ trait XmlDecoder[A] extends XmlDecoderIterable[A] {
     val cursor = new Cursor(sr)
     try {
       cursor.next()
-      while (
-        cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT
-      ) {
+      while (cursor.getEventType != XMLStreamConstants.START_ELEMENT) {
         cursor.next()
       }
       elementdecoder
@@ -85,4 +83,8 @@ object XmlDecoder {
       localName: String,
   )(implicit elementDecoder: ElementDecoder[A], namespace: Namespace[NS]): XmlDecoder[A] =
     fromElementDecoder(localName, Some(namespace.getNamespace))
+
+  private[phobos] def isIgnorableEvent(event: Int): Boolean =
+    event == XMLStreamConstants.DTD || event == XMLStreamConstants.START_DOCUMENT ||
+      event == XMLStreamConstants.SPACE || event == XMLStreamConstants.COMMENT
 }

--- a/modules/core/src/test/scala/phobos/XmlDecoderTest.scala
+++ b/modules/core/src/test/scala/phobos/XmlDecoderTest.scala
@@ -1,0 +1,36 @@
+package phobos
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import phobos.decoding.{ElementDecoder, XmlDecoder}
+import phobos.derivation.semiauto.deriveElementDecoder
+
+class XmlDecoderTest extends AnyWordSpec with Matchers {
+  "XmlDecoder" should {
+    "not fail on comments and other events before the first element" in {
+      case class Foo(bar: String)
+
+      implicit val fooElementDecoder: ElementDecoder[Foo] =
+        deriveElementDecoder[Foo]
+      implicit val xmlDecoder: XmlDecoder[Foo] =
+        XmlDecoder.fromElementDecoder("foo")
+
+      val result =
+        XmlDecoder[Foo]
+          .decode(
+            """<?xml version="1.1" encoding="UTF-8"?>
+              |
+              |
+              |
+              |<!-- comment -->
+              |
+              |<foo>
+              |    <bar>bar</bar>
+              |</foo>
+              |""".stripMargin,
+          )
+
+      result shouldBe Right(Foo("bar"))
+    }
+  }
+}

--- a/modules/fs2-ce2/src/main/scala/phobos/fs2/Fs2Ops.scala
+++ b/modules/fs2-ce2/src/main/scala/phobos/fs2/Fs2Ops.scala
@@ -24,9 +24,7 @@ class DecoderOps[A](private val xmlDecoder: XmlDecoder[A]) extends AnyVal {
       .fold[ElementDecoder[A]](xmlDecoder.elementdecoder) { (decoder, bytes) =>
         sr.getInputFeeder.feedInput(bytes, 0, bytes.length)
         cursor.next()
-        while (
-          cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT
-        ) {
+        while (XmlDecoder.isIgnorableEvent(cursor.getEventType)) {
           cursor.next()
         }
 

--- a/modules/fs2/src/main/scala/phobos/fs2/Fs2Ops.scala
+++ b/modules/fs2/src/main/scala/phobos/fs2/Fs2Ops.scala
@@ -24,9 +24,7 @@ class DecoderOps[A](private val xmlDecoder: XmlDecoder[A]) extends AnyVal {
       .fold[ElementDecoder[A]](xmlDecoder.elementdecoder) { (decoder, bytes) =>
         sr.getInputFeeder.feedInput(bytes, 0, bytes.length)
         cursor.next()
-        while (
-          cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT
-        ) {
+        while (XmlDecoder.isIgnorableEvent(cursor.getEventType)) {
           cursor.next()
         }
 

--- a/modules/monix/src/main/scala/phobos/monix/ops/MonixOps.scala
+++ b/modules/monix/src/main/scala/phobos/monix/ops/MonixOps.scala
@@ -20,9 +20,7 @@ class DecoderOps[A](private val xmlDecoder: XmlDecoder[A]) extends AnyVal {
       .foldLeftL[ElementDecoder[A]](xmlDecoder.elementdecoder) { (decoder, bytes) =>
         sr.getInputFeeder.feedInput(bytes, 0, bytes.length)
         cursor.next()
-        while (
-          cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT
-        ) {
+        while (XmlDecoder.isIgnorableEvent(cursor.getEventType)) {
           cursor.next()
         }
 


### PR DESCRIPTION
This PR fixes a bug when XmlDecoder fails on documents with comments before the first element like this one:
```xml
<?xml version="1.1" encoding="utf-8"?>
<!-- comment -->
<foo>
  <bar>bar</bar>
</foo>
```