### PR TITLE
fix: preserve XML 1.0 whitespace chars (\t, \n, \r) in element text

### DIFF
--- a/modules/core/src/main/scala/phobos/encoding/PhobosStreamWriter.scala
+++ b/modules/core/src/main/scala/phobos/encoding/PhobosStreamWriter.scala
@@ -326,7 +326,7 @@ object PhobosStreamWriter {
   val prefixBase = "ans"
 
   def isValidXmlCharacter(char: Char): Boolean =
-    !(char < ' '
+    !(char < ' ' && char != 0x9 && char != 0xA && char != 0xD
       || 0xd800 <= char && char <= 0xdfff
       || char == 0xfffe || char == 0xffff)
 }

--- a/modules/core/src/test/scala/phobos/XmlEncoderTest.scala
+++ b/modules/core/src/test/scala/phobos/XmlEncoderTest.scala
@@ -32,5 +32,21 @@ class XmlEncoderTest extends AnyWordSpec with Matchers {
         .encodeWithConfig(Foo(1, "abc", 1.0), XmlEncoder.XmlEncoderConfig("UTF-16", "1.1", writeProlog = true)) shouldBe
         Right("<?xml version='1.1' encoding='UTF-16'?><Foo><a>1</a><b>abc</b><c>1.0</c></Foo>")
     }
+
+    "preserve XML 1.0 whitespace characters (\\t, \\n, \\r) in element text" in {
+      // Real-world freeform XML element text — multi-line property descriptions,
+      // postal addresses, customer messages — routinely contains `\n` and `\t`
+      // characters. XML 1.0 §2.2 admits #x9, #xA, #xD as legal characters; before
+      // this fix `filterXmlText` silently stripped them, mangling the text on the
+      // wire (downstream consumers reported multi-paragraph descriptions arriving
+      // as a single line of run-on text).
+      final case class Listing(description: String)
+      implicit val listingEncoder: XmlEncoder[Listing] = deriveXmlEncoder("Listing")
+
+      val description = "Charming 2-bedroom cottage.\n\nFeatures:\n\tStone fireplace\n\tPrivate dock"
+
+      XmlEncoder[Listing].encodeWithConfig(Listing(description), XmlEncoder.defaultConfig.withoutProlog) shouldBe
+        Right(s"<Listing><description>$description</description></Listing>")
+    }
   }
 }


### PR DESCRIPTION
## Summary

`PhobosStreamWriter.isValidXmlCharacter` rejects every char below U+0020, so `filterXmlText` silently strips tab (`\t` / `#x9`), newline (`\n` / `#xA`), and carriage return (`\r` / `#xD`) from every encoded element-text, attribute value, comment, CDATA section, and raw output.

Per the XML 1.0 spec, [§2.2 "Characters"](https://www.w3.org/TR/xml/#charsets), all three are explicitly legal:

```
Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
```

## Why

Current predicate (drops `\t`/`\n`/`\r`):

```scala
def isValidXmlCharacter(char: Char): Boolean =
  !(char < ' '
    || 0xd800 <= char && char <= 0xdfff
    || char == 0xfffe || char == 0xffff)
```

Corrected predicate (refines the lower-bound clause to exempt the three legal whitespace chars in place):

```scala
def isValidXmlCharacter(char: Char): Boolean =
  !(char < ' ' && char != 0x9 && char != 0xA && char != 0xD
    || 0xd800 <= char && char <= 0xdfff
    || char == 0xfffe || char == 0xffff)
```

The first clause now reads "below space, except tab/newline/CR" — which matches XML 1.0 §2.2 exactly. The underlying StAX writer (woodstox) already accepts these characters, so they survive a round trip end-to-end.

This is a regression from 0.19.2 — that release had no `filterXmlText` at all, so all characters were passed through unchanged. The filter was introduced in 41c5d25 ("Less error throwing"), where the predicate was written too strictly for content characters.

## Test coverage

Regression test in `XmlEncoderTest`: a string carrying an embedded newline now round-trips through `XmlEncoder` instead of arriving line-stripped.

## Downstream impact

Downstream consumers sending multi-paragraph element text to XML APIs (e.g. multi-paragraph descriptions to vacation-rental APIs) currently see their content arrive as a single line of run-on text. With this fix the original line breaks and tabs are preserved, matching pre-0.19.2 behavior and the XML 1.0 spec.