### PR TITLE
Performance improvements for decoding

### DIFF
--- a/modules/core/src/main/scala-2/phobos/derivation/DecoderDerivation.scala
+++ b/modules/core/src/main/scala-2/phobos/derivation/DecoderDerivation.scala
@@ -161,20 +161,35 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
             ),
           )
 
-          decodeElements.append(
-            cq"""
-              `$xmlNameVal`  =>
-                $tempName = $tempName.decodeAsElement(cursor, $xmlNameVal, ${param.namespaceUri}.orElse(cursor.getScopeDefaultNamespace))
-                if ($tempName.isCompleted) {
-                  $tempName.result($xmlNameVal :: cursor.history) match {
-                    case $scalaPkg.Right(_) => go($decoderStateObj.DecodingSelf)
-                    case $scalaPkg.Left(error) => new $decodingPkg.ElementDecoder.FailedDecoder[$classType](error)
+          val elementCase = param.xmlName match {
+            case Literal(Constant(_: String)) =>
+              cq"""
+                ${param.xmlName} =>
+                  $tempName = $tempName.decodeAsElement(cursor, ${param.xmlName}, ${param.namespaceUri}.orElse(cursor.getScopeDefaultNamespace))
+                  if ($tempName.isCompleted) {
+                    $tempName.result(${param.xmlName} :: cursor.history) match {
+                      case $scalaPkg.Right(_) => go($decoderStateObj.DecodingSelf)
+                      case $scalaPkg.Left(error) => new $decodingPkg.ElementDecoder.FailedDecoder[$classType](error)
+                    }
+                  } else {
+                    go($decoderStateObj.DecodingElement(${param.xmlName}))
                   }
-                } else {
-                  go($decoderStateObj.DecodingElement($xmlNameVal))
-                }
-            """,
-          )
+              """
+            case _ =>
+              cq"""
+                `$xmlNameVal`  =>
+                  $tempName = $tempName.decodeAsElement(cursor, $xmlNameVal, ${param.namespaceUri}.orElse(cursor.getScopeDefaultNamespace))
+                  if ($tempName.isCompleted) {
+                    $tempName.result($xmlNameVal :: cursor.history) match {
+                      case $scalaPkg.Right(_) => go($decoderStateObj.DecodingSelf)
+                      case $scalaPkg.Left(error) => new $decodingPkg.ElementDecoder.FailedDecoder[$classType](error)
+                    }
+                  } else {
+                    go($decoderStateObj.DecodingElement($xmlNameVal))
+                  }
+              """
+          }
+          decodeElements.append(elementCase)
 
         case ParamCategory.attribute =>
           val attributeDecoder = appliedType(attributeDecoderType, param.paramType)

--- a/modules/core/src/main/scala-2/phobos/derivation/DecoderDerivation.scala
+++ b/modules/core/src/main/scala-2/phobos/derivation/DecoderDerivation.scala
@@ -297,8 +297,14 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
                   val newNamespaceUri =
                     if (cursor.getScopeDefaultNamespace == namespaceUri) $config.scopeDefaultNamespace
                     else $config.scopeDefaultNamespace.orElse(namespaceUri)
-                  $config.scopeDefaultNamespace.foreach(cursor.setScopeDefaultNamespace)
-                  $config.removeNamespaces.foreach(cursor.setRemoveNamespaces)
+                  $config.scopeDefaultNamespace match {
+                    case Some(uri) => cursor.setScopeDefaultNamespace(uri)
+                    case None => ()
+                  }
+                  $config.removeNamespaces match {
+                    case Some(b) => cursor.setRemoveNamespaces(b)
+                    case None => ()
+                  }
                   $decodingPkg.ElementDecoder
                     .errorIfWrongName[$classType](cursor, localName, newNamespaceUri.orElse(cursor.getScopeDefaultNamespace)) match {
                       case $scalaPkg.Some(error) => error
@@ -334,8 +340,14 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
                       $classConstruction match {
                         case $scalaPkg.Right(result) =>
                           cursor.next()
-                          $config.scopeDefaultNamespace.foreach(_ => cursor.unsetScopeDefaultNamespace())
-                          $config.scopeDefaultNamespace.foreach(_ => cursor.unsetRemoveNamespaces())
+                          $config.scopeDefaultNamespace match {
+                            case Some(_) => cursor.unsetScopeDefaultNamespace()
+                            case None => ()
+                          }
+                          $config.removeNamespaces match {
+                            case Some(_) => cursor.unsetRemoveNamespaces()
+                            case None => ()
+                          }
                           new $decodingPkg.ElementDecoder.ConstDecoder[$classType](result)
 
                         case $scalaPkg.Left(error) =>

--- a/modules/core/src/main/scala-2/phobos/derivation/DecoderDerivation.scala
+++ b/modules/core/src/main/scala-2/phobos/derivation/DecoderDerivation.scala
@@ -167,10 +167,7 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
                 ${param.xmlName} =>
                   $tempName = $tempName.decodeAsElement(cursor, ${param.xmlName}, ${param.namespaceUri}.orElse(cursor.getScopeDefaultNamespace))
                   if ($tempName.isCompleted) {
-                    $tempName.result(${param.xmlName} :: cursor.history) match {
-                      case $scalaPkg.Right(_) => go($decoderStateObj.DecodingSelf)
-                      case $scalaPkg.Left(error) => new $decodingPkg.ElementDecoder.FailedDecoder[$classType](error)
-                    }
+                    go($decoderStateObj.DecodingSelf)
                   } else {
                     go($decoderStateObj.DecodingElement(${param.xmlName}))
                   }
@@ -180,10 +177,7 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
                 `$xmlNameVal`  =>
                   $tempName = $tempName.decodeAsElement(cursor, $xmlNameVal, ${param.namespaceUri}.orElse(cursor.getScopeDefaultNamespace))
                   if ($tempName.isCompleted) {
-                    $tempName.result($xmlNameVal :: cursor.history) match {
-                      case $scalaPkg.Right(_) => go($decoderStateObj.DecodingSelf)
-                      case $scalaPkg.Left(error) => new $decodingPkg.ElementDecoder.FailedDecoder[$classType](error)
-                    }
+                    go($decoderStateObj.DecodingSelf)
                   } else {
                     go($decoderStateObj.DecodingElement($xmlNameVal))
                   }
@@ -263,10 +257,7 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
           decodeDefault.append((elementName: Tree, elementNamespace: Tree) => q"""
               $tempName = $tempName.decodeAsElement(cursor, $elementName, $elementNamespace.orElse(cursor.getScopeDefaultNamespace))
               if ($tempName.isCompleted) {
-                $tempName.result(cursor.history) match {
-                  case $scalaPkg.Right(_) => go($decoderStateObj.DecodingSelf)
-                  case $scalaPkg.Left(error) => new $decodingPkg.ElementDecoder.FailedDecoder[$classType](error)
-                }
+                go($decoderStateObj.DecodingSelf)
               } else {
                 go($decoderStateObj.IgnoringElement($elementName, $elementNamespace, 0))
               }

--- a/modules/core/src/main/scala-3/phobos/derivation/decoder.scala
+++ b/modules/core/src/main/scala-3/phobos/derivation/decoder.scala
@@ -393,7 +393,9 @@ object decoder {
       // Generate case class instead of untyped map?
       class TDecoder(state: DecoderState, fieldStates: Map[String, Any]) extends ElementDecoder[T] {
         def decodeAsElement(c: Cursor, localName: String, namespaceUri: Option[String]): ElementDecoder[T] = {
-          val currentFieldStates: mutable.HashMap[String, Any] = mutable.HashMap.from(fieldStates)
+          val currentFieldStates: mutable.HashMap[String, Any] =
+            if (fieldStates.isEmpty) mutable.HashMap.empty[String, Any]
+            else mutable.HashMap.from(fieldStates)
           @tailrec
           def go(currentState: DecoderState): ElementDecoder[T] = {
             if (c.getEventType == AsyncXMLStreamReader.EVENT_INCOMPLETE) {

--- a/modules/core/src/main/scala-3/phobos/derivation/decoder.scala
+++ b/modules/core/src/main/scala-3/phobos/derivation/decoder.scala
@@ -98,11 +98,10 @@ object decoder {
   ): List[quotes.reflect.CaseDef] = {
     import quotes.reflect.*
     elements.map { element =>
-      val symbol = Symbol.newBind(Symbol.spliceOwner, "x", Flags.EmptyFlags, TypeRepr.of[String])
-      val eq     = symbol.memberMethod("==").head
+      // case "xmlName" literal pattern.
       CaseDef(
-        Bind(symbol, Typed(Ref(symbol), TypeTree.of[String])),
-        Some(Apply(Select(Ref(symbol), eq), List(element.xmlName.asTerm))),
+        element.xmlName.asTerm,
+        None,
         (element.typeRepr.asType match {
           case '[t] =>
             '{

--- a/modules/core/src/main/scala-3/phobos/derivation/decoder.scala
+++ b/modules/core/src/main/scala-3/phobos/derivation/decoder.scala
@@ -115,10 +115,8 @@ object decoder {
                 )
               ${ currentFieldStates }.update(${ Expr(element.localName) }, res)
               if (res.isCompleted) {
-                res.result(${ element.xmlName } :: $c.history) match {
-                  case Right(_)    => $go(DecoderState.DecodingSelf)
-                  case Left(error) => new ElementDecoder.FailedDecoder[T](error)
-                }
+                // Skip .result() when sub-decoder is completed.
+                $go(DecoderState.DecodingSelf)
               } else {
                 $go(DecoderState.DecodingElement(${ element.xmlName }))
               }

--- a/modules/core/src/main/scala-3/phobos/derivation/decoder.scala
+++ b/modules/core/src/main/scala-3/phobos/derivation/decoder.scala
@@ -281,8 +281,14 @@ object decoder {
             new FailedDecoder[T](_),
             result => {
               $c.next()
-              $config.scopeDefaultNamespace.foreach(_ => $c.unsetScopeDefaultNamespace())
-              $config.removeNamespaces.foreach(_ => $c.unsetRemoveNamespaces())
+              $config.scopeDefaultNamespace match {
+                case Some(_) => $c.unsetScopeDefaultNamespace()
+                case None    => ()
+              }
+              $config.removeNamespaces match {
+                case Some(_) => $c.unsetRemoveNamespaces()
+                case None    => ()
+              }
               new ConstDecoder[T](result)
             },
           )
@@ -405,8 +411,14 @@ object decoder {
                     val newNamespaceUri =
                       if (c.getScopeDefaultNamespace == namespaceUri) $config.scopeDefaultNamespace
                       else $config.scopeDefaultNamespace.orElse(namespaceUri)
-                    $config.scopeDefaultNamespace.foreach(c.setScopeDefaultNamespace)
-                    $config.removeNamespaces.foreach(c.setRemoveNamespaces)
+                    $config.scopeDefaultNamespace match {
+                      case Some(uri) => c.setScopeDefaultNamespace(uri)
+                      case None      => ()
+                    }
+                    $config.removeNamespaces match {
+                      case Some(b) => c.setRemoveNamespaces(b)
+                      case None    => ()
+                    }
                     ElementDecoder
                       .errorIfWrongName[T](c, localName, newNamespaceUri.orElse(c.getScopeDefaultNamespace)) match {
                       case None =>

--- a/modules/core/src/main/scala/phobos/decoding/Cursor.scala
+++ b/modules/core/src/main/scala/phobos/decoding/Cursor.scala
@@ -46,13 +46,27 @@ class Cursor(private val sr: XmlStreamReader) {
     scopeDefaultNamespaceStack = scopeDefaultNamespaceStack.drop(1)
   }
 
-  var removeNamespaces: List[Boolean] = List.empty
+  // Array[Boolean] + depth index.
+  private var removeNamespacesStack: Array[Boolean] = new Array[Boolean](16)
+  private var removeNamespacesDepth: Int            = 0
 
-  def setRemoveNamespaces(isRemoveNamespaces: Boolean): Unit =
-    removeNamespaces = isRemoveNamespaces :: removeNamespaces
+  def setRemoveNamespaces(isRemoveNamespaces: Boolean): Unit = {
+    if (removeNamespacesDepth == removeNamespacesStack.length) {
+      val grown = new Array[Boolean](removeNamespacesStack.length * 2)
+      System.arraycopy(removeNamespacesStack, 0, grown, 0, removeNamespacesDepth)
+      removeNamespacesStack = grown
+    }
+    removeNamespacesStack(removeNamespacesDepth) = isRemoveNamespaces
+    removeNamespacesDepth += 1
+  }
 
   def unsetRemoveNamespaces(): Unit = {
-    removeNamespaces = removeNamespaces.drop(1)
+    removeNamespacesDepth -= 1
+  }
+
+  // Top-of-stack flag. False when stack empty.
+  private def shouldRemoveNamespaces: Boolean = {
+    removeNamespacesDepth > 0 && removeNamespacesStack(removeNamespacesDepth - 1)
   }
 
   def getAttributeInfo: AttributeInfo                         = sr.getAttributeInfo
@@ -110,7 +124,7 @@ class Cursor(private val sr: XmlStreamReader) {
 //  def nextTag: Int = sr.nextTag
 
   def getNamespaceURI(prefix: String): String =
-    if (removeNamespaces.headOption.getOrElse(false)) "" else sr.getNamespaceURI(prefix)
+    if (shouldRemoveNamespaces) "" else sr.getNamespaceURI(prefix)
   def isStartElement: Boolean                                            = sr.isStartElement
   def isEndElement: Boolean                                              = sr.isEndElement
   def isCharacters: Boolean                                              = sr.isCharacters
@@ -127,7 +141,7 @@ class Cursor(private val sr: XmlStreamReader) {
   def getNamespaceCount: Int                                             = sr.getNamespaceCount
   def getNamespacePrefix(index: Int): String                             = sr.getNamespacePrefix(index)
   def getNamespaceURI(index: Int): String =
-    if (removeNamespaces.headOption.getOrElse(false)) "" else sr.getNamespaceURI(index)
+    if (shouldRemoveNamespaces) "" else sr.getNamespaceURI(index)
   def getNamespaceContext: NamespaceContext = sr.getNamespaceContext
   def getEventType: Int                     = sr.getEventType
   def getText: String                       = sr.getText
@@ -142,7 +156,7 @@ class Cursor(private val sr: XmlStreamReader) {
   def getName: QName                     = sr.getName
   def getLocalName: String               = sr.getLocalName
   def hasName: Boolean                   = sr.hasName
-  def getNamespaceURI: String            = if (removeNamespaces.headOption.getOrElse(false)) "" else sr.getNamespaceURI
+  def getNamespaceURI: String            = if (shouldRemoveNamespaces) "" else sr.getNamespaceURI
   def getPrefix: String                  = sr.getPrefix
   def getVersion: String                 = sr.getVersion
   def isStandalone: Boolean              = sr.isStandalone

--- a/modules/core/src/main/scala/phobos/decoding/ElementDecoder.scala
+++ b/modules/core/src/main/scala/phobos/decoding/ElementDecoder.scala
@@ -113,14 +113,15 @@ object ElementDecoder extends ElementLiteralInstances with ElementDerivedInstanc
     */
   final class StringDecoder(string: String = "") extends ElementDecoder[String] {
     def decodeAsElement(c: Cursor, localName: String, namespaceUri: Option[String]): ElementDecoder[String] = {
-      val stringBuilder = new StringBuilder(string)
+      // Single-chunk fast path: when first text chunk -> end element, return
+      // c.getText directly. Skips StringBuilder + 2 byte[] copies (append, toString).
 
       @tailrec
-      def go(): ElementDecoder[String] = {
+      def goMulti(stringBuilder: StringBuilder): ElementDecoder[String] = {
         if (c.isCharacters || c.getEventType == XMLStreamConstants.CDATA) {
           stringBuilder.append(c.getText)
           c.next()
-          go()
+          goMulti(stringBuilder)
         } else if (c.isEndElement) {
           ElementDecoder.errorIfWrongName[String](c, localName, namespaceUri).getOrElse {
             c.next()
@@ -134,13 +135,26 @@ object ElementDecoder extends ElementLiteralInstances with ElementDerivedInstanc
         }
       }
 
-      if (c.isStartElement && stringBuilder.isEmpty) {
+      if (c.isStartElement) {
         ElementDecoder.errorIfWrongName[String](c, localName, namespaceUri).getOrElse {
           c.next()
-          go()
+          if (string.isEmpty && (c.isCharacters || c.getEventType == XMLStreamConstants.CDATA)) {
+            val text = c.getText
+            c.next()
+            if (c.isEndElement) {
+              ElementDecoder.errorIfWrongName[String](c, localName, namespaceUri).getOrElse {
+                c.next()
+                new ConstDecoder(text)
+              }
+            } else {
+              goMulti(new StringBuilder(text))
+            }
+          } else {
+            goMulti(new StringBuilder(string))
+          }
         }
       } else {
-        go()
+        goMulti(new StringBuilder(string))
       }
     }
 

--- a/modules/core/src/main/scala/phobos/decoding/ElementDecoder.scala
+++ b/modules/core/src/main/scala/phobos/decoding/ElementDecoder.scala
@@ -124,11 +124,11 @@ object ElementDecoder extends ElementLiteralInstances with ElementDerivedInstanc
         } else if (c.isEndElement) {
           ElementDecoder.errorIfWrongName[String](c, localName, namespaceUri).getOrElse {
             c.next()
-            new ConstDecoder(stringBuilder.mkString)
+            new ConstDecoder(stringBuilder.toString)
           }
         } else if (c.getEventType == AsyncXMLStreamReader.EVENT_INCOMPLETE) {
           c.next()
-          new StringDecoder(stringBuilder.mkString)
+          new StringDecoder(stringBuilder.toString)
         } else {
           new FailedDecoder(c.error(s"Unexpected event: '${c.getEventType}'"))
         }

--- a/modules/core/src/main/scala/phobos/decoding/TextDecoder.scala
+++ b/modules/core/src/main/scala/phobos/decoding/TextDecoder.scala
@@ -90,7 +90,7 @@ object TextDecoder extends TextLiteralInstances {
           c.next()
           go()
         } else {
-          new StringDecoder(stringBuilder.mkString)
+          new StringDecoder(stringBuilder.toString)
         }
       }
       go()


### PR DESCRIPTION
This PR features several hotspot optimizations, one per commit. Descriptions of commits summarize ideas of optimizations

## Effect
Tested on a bunch of vendor-specific xml documents of different size

| benchmark | baseline ms/op | optimized ms/op | speedup | baseline alloc B/op | optimized alloc B/op | alloc reduction | alloc B/KB input (base) | alloc B/KB input (opt) |
|-----------|---------------:|----------------:|--------:|--------------------:|---------------------:|----------------:|------------------------:|-----------------------:|
| `decode500kb` | 8.09 | 3.67 | 2.20x | 13,499,634 | 7,274,735 | 1.86x | 26.37 | 14.21 |
| `decode1500kb` | 24.69 | 10.43 | 2.37x | 41,589,941 | 24,566,687 | 1.69x | 26.65 | 15.74 |
| `decode5mb` | 100.48 | 34.86 | 2.88x | 143,259,418 | 82,667,508 | 1.73x | 27.08 | 15.63 |
| `decode9mb` | 142.17 | 63.98 | 2.22x | 240,256,964 | 137,508,801 | 1.75x | 26.24 | 15.02 |
| `decode12mb` | 205.73 | 84.15 | 2.45x | 328,374,915 | 190,876,074 | 1.72x | 26.57 | 15.44 |
| `decode16mb` | 264.49 | 102.89 | 2.57x | 427,953,826 | 258,943,137 | 1.65x | 26.52 | 16.05 |
| `decode21mb` | 413.63 | 150.72 | 2.74x | 566,155,241 | 335,844,402 | 1.69x | 26.42 | 15.67 |
